### PR TITLE
feat: implement skeleton for app data models

### DIFF
--- a/app/src/main/java/com/android/wildex/model/achievement/Achievement.kt
+++ b/app/src/main/java/com/android/wildex/model/achievement/Achievement.kt
@@ -1,0 +1,19 @@
+package com.android.wildex.model.achievement
+
+/**
+ * Represents an achievement earned by a user.
+ *
+ * @property achievementId The unique identifier for the achievement.
+ * @property picture The URL/URI of the image associated with the achievement.
+ * @property description A description of the achievement.
+ * @property name The name of the achievement.
+ * @property condition A lambda function that takes a list of posts and returns true if the
+ *   achievement conditions are met.
+ */
+data class Achievement(
+    val achievementId: String,
+    val picture: String,
+    val description: String,
+    val name: String,
+    val condition: (List<String>) -> Boolean,
+)

--- a/app/src/main/java/com/android/wildex/model/animal/Animal.kt
+++ b/app/src/main/java/com/android/wildex/model/animal/Animal.kt
@@ -1,0 +1,18 @@
+package com.android.wildex.model.animal
+
+/**
+ * Represents an animal in the system.
+ *
+ * @property animalId The unique identifier for the animal.
+ * @property picture The URL/URI of the animal's image.
+ * @property name The name of the animal.
+ * @property species The species of the animal.
+ * @property description A description of the animal.
+ */
+data class Animal(
+    val animalId: String,
+    val picture: String,
+    val name: String,
+    val species: String,
+    val description: String,
+)

--- a/app/src/main/java/com/android/wildex/model/relationship/Relationship.kt
+++ b/app/src/main/java/com/android/wildex/model/relationship/Relationship.kt
@@ -1,0 +1,16 @@
+package com.android.wildex.model.relationship
+
+/**
+ * Represents a relationship between two users.
+ *
+ * @property senderId The ID of the user who sent the relationship request.
+ * @property receiverId The ID of the user who received the relationship request.
+ * @property status The status of the relationship, defined by the StatusEnum.
+ */
+data class Relationship(val senderId: String, val receiverId: String, val status: StatusEnum)
+
+/** Enum class representing the status of a relationship. */
+enum class StatusEnum {
+  PENDING,
+  ACCEPTED,
+}

--- a/app/src/main/java/com/android/wildex/model/report/Report.kt
+++ b/app/src/main/java/com/android/wildex/model/report/Report.kt
@@ -1,0 +1,33 @@
+package com.android.wildex.model.report
+
+import com.android.wildex.model.utils.Location
+import com.google.firebase.Timestamp
+
+/**
+ * Represents a report made by a user regarding an animal or post.
+ *
+ * @property reportId The unique identifier for the report.
+ * @property image The URL/URI of the image being reported.
+ * @property location The location where the report was made.
+ * @property date The date and time when the report was created.
+ * @property description A description of why the report was made.
+ * @property authorId The ID of the user who made the report.
+ * @property assigneeId The ID of the user assigned to handle the report.
+ * @property status The status of the report, defined by the ReportStatus enum.
+ */
+data class Report(
+    val reportId: String,
+    val image: String,
+    val location: Location,
+    val date: Timestamp,
+    val description: String,
+    val authorId: String,
+    val assigneeId: String,
+    val status: ReportStatus,
+)
+
+/** Enum class representing the status of a report. */
+enum class ReportStatus {
+  PENDING,
+  RESOLVED,
+}

--- a/app/src/main/java/com/android/wildex/model/social/Comment.kt
+++ b/app/src/main/java/com/android/wildex/model/social/Comment.kt
@@ -1,0 +1,20 @@
+package com.android.wildex.model.social
+
+import com.google.firebase.Timestamp
+
+/**
+ * Represents a comment on a post.
+ *
+ * @property commentId The unique identifier for the comment.
+ * @property postId The ID of the post that this comment belongs to.
+ * @property authorId The ID of the user who made the comment.
+ * @property text The content of the comment.
+ * @property date The date and time when the comment was made.
+ */
+data class Comment(
+    val commentId: String,
+    val postId: String,
+    val authorId: String,
+    val text: String,
+    val date: Timestamp,
+)

--- a/app/src/main/java/com/android/wildex/model/social/Like.kt
+++ b/app/src/main/java/com/android/wildex/model/social/Like.kt
@@ -1,0 +1,10 @@
+package com.android.wildex.model.social
+
+/**
+ * Represents a like on a post.
+ *
+ * @property likeId The unique identifier for the like.
+ * @property postId The ID of the post that was liked.
+ * @property userId The ID of the user who liked the post.
+ */
+data class Like(val likeId: String, val postId: String, val userId: String)

--- a/app/src/main/java/com/android/wildex/model/social/Post.kt
+++ b/app/src/main/java/com/android/wildex/model/social/Post.kt
@@ -1,0 +1,27 @@
+package com.android.wildex.model.social
+
+import com.android.wildex.model.utils.Location
+import com.google.firebase.Timestamp
+
+/**
+ * Represents a post made by a user.
+ *
+ * @property postId The unique identifier for the post.
+ * @property authorId The ID of the user who created the post.
+ * @property picture The URL/URI of the image in the post.
+ * @property location The location where the post was made.
+ * @property date The date and time when the post was created.
+ * @property animalId The ID of the animal related to the post.
+ * @property likesCount The number of likes the post has received.
+ * @property commentsCount The number of comments the post has received.
+ */
+data class Post(
+    val postId: String,
+    val authorId: String,
+    val picture: String,
+    val location: Location,
+    val date: Timestamp,
+    val animalId: String,
+    val likesCount: Int,
+    val commentsCount: Int,
+)

--- a/app/src/main/java/com/android/wildex/model/user/User.kt
+++ b/app/src/main/java/com/android/wildex/model/user/User.kt
@@ -1,0 +1,44 @@
+package com.android.wildex.model.user
+
+import com.google.firebase.Timestamp
+
+/**
+ * Represents a user in the system.
+ *
+ * @property userId Unique identifier for the user.
+ * @property username The username chosen by the user.
+ * @property name The first name of the user.
+ * @property surname The last name of the user.
+ * @property bio A short biography or description of the user.
+ * @property profilePicture The URL/URI of the user's profile picture.
+ * @property userType The type of user, defined by the UserType enum.
+ * @property creationDate The date the user's account was created.
+ * @property country The country the user is from.
+ * @property friendsCount The number of friends the user has.
+ * @property animalsId List of animal IDs the user has interacted with.
+ * @property animalsCount The number of animals the user has interacted with.
+ * @property achievementsId List of achievement IDs the user has earned.
+ * @property achievementsCount The number of achievements the user has earned.
+ */
+data class User(
+    val userId: String,
+    val username: String,
+    val name: String,
+    val surname: String,
+    val bio: String,
+    val profilePicture: String,
+    val userType: UserType,
+    val creationDate: Timestamp,
+    val country: String,
+    val friendsCount: Int,
+    val animalsId: List<String>,
+    val animalsCount: Int,
+    val achievementsId: List<String>,
+    val achievementsCount: Int,
+)
+
+/** Enum class representing the type of user. */
+enum class UserType {
+  REGULAR,
+  PROFESSIONAL,
+}

--- a/app/src/main/java/com/android/wildex/model/utils/Location.kt
+++ b/app/src/main/java/com/android/wildex/model/utils/Location.kt
@@ -1,0 +1,10 @@
+package com.android.wildex.model.utils
+
+/**
+ * Represents a geographical location with latitude and longitude.
+ *
+ * @property latitude The latitude of the location.
+ * @property longitude The longitude of the location.
+ * @property name The name of the location.
+ */
+data class Location(val latitude: Double, val longitude: Double, val name: String = "")


### PR DESCRIPTION
## Title:
Implement Skeleton for Data Models

## Purpose of the change
This PR adds the basic structure for the app's core data models: User,
Relationship, Post, Comment, Like, Report, Achievement, and Animal.
These models define the necessary fields for handling user data, posts,
comments, achievements, and animals.

## Trade-offs or known limitations
None at this stage.