### PR TITLE
feat: implement achievement repository interface

### DIFF
--- a/app/src/main/java/com/android/wildex/model/achievement/AchievementsRepository.kt
+++ b/app/src/main/java/com/android/wildex/model/achievement/AchievementsRepository.kt
@@ -9,6 +9,12 @@ interface AchievementsRepository {
   /** Retrieves all Achievement items from the repository. */
   suspend fun getAllAchievements(): List<Achievement>
 
+  /** Retrieves all Achievement items associated with a specific user. */
+  suspend fun getAllAchievementsByUser(userId: String): List<Achievement>
+
+  /** Retrieves all Achievement items associated with the currently authenticated user. */
+  suspend fun getAllAchievementsByCurrentUser(): List<Achievement>
+
   /** Retrieves a specific Achievement item by its unique identifier. */
   suspend fun getAchievement(achievementId: String): Achievement
 


### PR DESCRIPTION
This PR implements the `AchievementsRepository` interface, defining different operations:

- Generating and returning a new unique identifier for an Achievement item.
- Retrieving all Achievement items from the repository.
- Retrieving all Achievement items associated with a specific user.
- Retrieving all Achievement items associated with the currently authenticated user.
- Retrieving a specific Achievement item by its unique identifier.
- Adding a new Achievement item to the repository.
- Editing an existing Achievement item in the repository.
- Deleting an Achievement item from the repository.

Closes #43 