### PR TITLE
Upgrade package versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,14 +62,14 @@ android {
     }
   }
 
-  testCoverage { jacocoVersion = "0.8.11" }
+  testCoverage { jacocoVersion = "0.8.12" }
 
   buildFeatures {
     compose = true
     buildConfig = true
   }
 
-  composeOptions { kotlinCompilerExtensionVersion = "1.4.2" }
+  composeOptions { kotlinCompilerExtensionVersion = "1.5.3" }
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,14 @@
 [versions]
 agp = "8.3.0"
-kotlin = "1.8.10"
+kotlin = "1.9.10"
 coreKtx = "1.12.0"
 ktfmt = "0.17.0"
-json = "20240303"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 appcompat = "1.6.1"
 material = "1.11.0"
-composeBom = "2024.02.02"
-composeActivity = "1.8.2"
-composeViewModel = "2.7.0"
+composeBom = "2024.08.00"
 lifecycleRuntimeKtx = "2.7.0"
 kaspresso = "1.5.5"
 robolectric = "4.11.1"
@@ -34,7 +31,6 @@ okhttp = "4.12.0"
 kotlinxSerializationJson = "1.6.2"
 
 # Testing
-mockito = "5.6.0"
 mockitoAndroid = "5.13.0"
 mockitoCore = "5.13.0"
 mockitoKotlin = "5.4.0"
@@ -48,7 +44,6 @@ navigationCompose = "2.7.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-json = { module = "org.json:json", version.ref = "json" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -66,8 +61,8 @@ compose-ui = { group = "androidx.compose.ui", name = "ui" }
 compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 compose-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 compose-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-compose-activity = { group = "androidx.activity", name = "activity-compose", version.ref = "composeActivity" }
-compose-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "composeViewModel" }
+compose-activity = { group = "androidx.activity", name = "activity-compose" }
+compose-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose" }
 compose-test-junit = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 


### PR DESCRIPTION
- The purpose for the PR was to fix the issue of SonarCloud no generating coverage for compose UI classes.
Upgraded package version for the following in`libs.versions.toml` and `build.gradle.kts` : jacoco / kotlinCompilerExtensionVersion / kotlin / composeBom.
Also Removed some unused libraries

- Closes #82