### PR TITLE
feat: Implement report repository interface

### DIFF
--- a/app/src/main/java/com/android/wildex/model/report/ReportRepository.kt
+++ b/app/src/main/java/com/android/wildex/model/report/ReportRepository.kt
@@ -1,26 +1,31 @@
 package com.android.wildex.model.report
 
+import com.android.wildex.model.utils.Id
+
 /** Represents a repository that manages Report items. */
 interface ReportRepository {
 
   /** Generates and returns a new unique identifier for a Report item. */
-  fun getNewReportId(): String
+  fun getNewReportId(): Id
 
   /** Retrieves all Reports items from the repository. */
   suspend fun getAllReports(): List<Report>
 
-  /** Retrieves all Reports items associated with a specific user. */
-  suspend fun getAllReportsByUser(userId: String): List<Report>
+  /** Retrieves all Reports items associated with a specific author. */
+  suspend fun getAllReportsByAuthor(authorId: Id): List<Report>
+
+  /** Retrieves all Reports items associated with a specific assignee. */
+  suspend fun getAllReportsByAssignee(assigneeId: Id): List<Report>
 
   /** Retrieves a specific Report item by its unique identifier. */
-  suspend fun getReport(reportId: String): Report
+  suspend fun getReport(reportId: Id): Report
 
   /** Adds a new Report item to the repository. */
   suspend fun addReport(report: Report)
 
   /** Edits an existing Report item in the repository. */
-  suspend fun editPost(reportId: String, newValue: Report)
+  suspend fun editPost(reportId: Id, newValue: Report)
 
   /** Deletes a Report item from the repository. */
-  suspend fun deleteReport(reportId: String)
+  suspend fun deleteReport(reportId: Id)
 }


### PR DESCRIPTION
## Description
This PR implements the `ReportRepository` interface, providing the following operations:
- **Generate** a new unique identifier for a `Report` item.
- **Retrieve** all `Report` items, those associated with a specific user, or only one by its unique identifier.
- **Add** a new `Report` item to the repository.
- **Edit** an existing `Report` item in the repository.
- **Delete** a `Report` item from the repository.

## Related issues
Updates #73 