### PR TITLE
feat: implement animal repository

### DIFF
--- a/app/src/androidTest/java/com/android/wildex/model/animal/AnimalRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/model/animal/AnimalRepositoryFirestoreTest.kt
@@ -1,0 +1,116 @@
+package com.android.wildex.model.animal
+
+import android.util.Log
+import com.android.wildex.utils.FirestoreTest
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+const val ANIMAL_COLLECTION_PATH = "animal"
+
+class AnimalRepositoryFirestoreTest : FirestoreTest(ANIMAL_COLLECTION_PATH) {
+  private var repository = AnimalRepositoryFirestore(Firebase.firestore)
+
+  @Before
+  override fun setUp() {
+    super.setUp()
+  }
+
+  @After
+  override fun tearDown() {
+    super.tearDown()
+  }
+
+  @Test
+  fun canAddAnimalToRepository() = runTest {
+    repository.addAnimal(animal1)
+    val animals = repository.getAllAnimals()
+    Log.e("AnimalRepositoryFirestoreTest", "Animals size: ${animals.size}")
+    assertEquals(1, animals.size)
+    val storedAnimal = animals.first()
+    Log.e("AnimalRepositoryFirestoreTest", "Expected animal: $animal1")
+    Log.e("AnimalRepositoryFirestoreTest", "Stored animal: $storedAnimal")
+    assertEquals(animal1, storedAnimal)
+  }
+
+  @Test
+  fun addAnimalWithSameNameDoesNotAddDouble() = runTest {
+    repository.addAnimal(animal1)
+    repository.addAnimal(animal1.copy(animalId = "Different Id"))
+    val animals = repository.getAllAnimals()
+    assertEquals(1, animals.size)
+    val storedAnimal = animals.first()
+    assertEquals(animal1, storedAnimal)
+  }
+
+  @Test
+  fun addAnimalWithExistingIdThrowsException() = runTest {
+    repository.addAnimal(animal1)
+    var exceptionThrown = false
+    try {
+      repository.addAnimal(animal1.copy(name = "Different Name"))
+    } catch (e: IllegalArgumentException) {
+      exceptionThrown = true
+      assertEquals(
+          "AnimalRepositoryFirestore: An animal with ID '${animal1.animalId}' already exists.",
+          e.message,
+      )
+    }
+    assert(exceptionThrown) { "Expected IllegalArgumentException was not thrown." }
+  }
+
+  @Test
+  fun canGetAnimalById() = runTest {
+    repository.addAnimal(animal1)
+    val animal = repository.getAnimal(animal1.animalId)
+    assertEquals(animal1, animal)
+  }
+
+  @Test
+  fun getAllAnimalsReturnsEmptyListWhenNoAnimalsAdded() = runTest {
+    val animals = repository.getAllAnimals()
+    assertTrue(animals.isEmpty())
+  }
+
+  @Test
+  fun canAddMultipleAnimalsAndRetrieveAll() = runTest {
+    repository.addAnimal(animal1)
+    repository.addAnimal(animal2)
+    val animals = repository.getAllAnimals()
+    assertEquals(2, animals.size)
+    assertTrue(animals.contains(animal1))
+    assertTrue(animals.contains(animal2))
+  }
+
+  @Test
+  fun getAnimalWithNonExistentIdThrowsException() = runTest {
+    var exceptionThrown = false
+    try {
+      repository.getAnimal("nonExistentId")
+    } catch (e: IllegalArgumentException) {
+      exceptionThrown = true
+      assertEquals("Animal with given Id nonExistentId not found", e.message)
+    }
+    assert(exceptionThrown) { "Expected IllegalArgumentException was not thrown." }
+  }
+
+  @Test
+  fun addAnimalWithMissingFieldsReturnsEmptyList() = runTest {
+    val invalidData =
+        mapOf("pictureURL" to "someUrl", "name" to "someName", "description" to "someDescription")
+    Firebase.firestore
+        .collection(ANIMAL_COLLECTION_PATH)
+        .document("invalidAnimalId")
+        .set(invalidData)
+        .await()
+
+    val animals = repository.getAllAnimals()
+    assertTrue(animals.isEmpty())
+  }
+}

--- a/app/src/androidTest/java/com/android/wildex/utils/FirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/utils/FirestoreTest.kt
@@ -1,6 +1,7 @@
 package com.android.wildex.utils
 
 import android.util.Log
+import com.android.wildex.model.animal.Animal
 import com.android.wildex.model.social.Comment
 import com.android.wildex.model.social.Like
 import com.android.wildex.model.social.Post
@@ -174,4 +175,22 @@ open class FirestoreTest(val collectionPath: String) {
           authorId = "author2",
           text = "text2",
           date = Timestamp.fromDate(2012, 12, 12))
+
+  open val animal1 =
+      Animal(
+          animalId = "animalId1",
+          pictureURL = "pictureURL1",
+          name = "animalName1",
+          species = "animalType1",
+          description = "animalDescription1",
+      )
+
+  open val animal2 =
+      Animal(
+          animalId = "animalId2",
+          pictureURL = "pictureURL2",
+          name = "animalName2",
+          species = "animalType2",
+          description = "animalDescription2",
+      )
 }

--- a/app/src/main/java/com/android/wildex/model/RepositoryProvider.kt
+++ b/app/src/main/java/com/android/wildex/model/RepositoryProvider.kt
@@ -3,7 +3,9 @@ package com.android.wildex.model
 import com.android.wildex.HttpClientProvider
 import com.android.wildex.model.achievement.UserAchievementsRepository
 import com.android.wildex.model.achievement.UserAchievementsRepositoryFirestore
-import com.android.wildex.model.animaldetector.AnimalRepository
+import com.android.wildex.model.animal.AnimalRepository
+import com.android.wildex.model.animal.AnimalRepositoryFirestore
+import com.android.wildex.model.animaldetector.AnimalInfoRepository
 import com.android.wildex.model.animaldetector.AnimalRepositoryHttp
 import com.android.wildex.model.authentication.AuthRepository
 import com.android.wildex.model.authentication.AuthRepositoryFirebase
@@ -35,6 +37,9 @@ object RepositoryProvider {
   val userAchievementsRepository: UserAchievementsRepository by lazy {
     UserAchievementsRepositoryFirestore(Firebase.firestore)
   }
-  val animalRepository: AnimalRepository by lazy { AnimalRepositoryHttp(HttpClientProvider.client) }
+  val animalInfoRepository: AnimalInfoRepository by lazy {
+    AnimalRepositoryHttp(HttpClientProvider.client)
+  }
   val storageRepository: StorageRepository by lazy { StorageRepositoryFirebase(Firebase.storage) }
+  val animalRepository: AnimalRepository by lazy { AnimalRepositoryFirestore(Firebase.firestore) }
 }

--- a/app/src/main/java/com/android/wildex/model/animal/AnimalRepository.kt
+++ b/app/src/main/java/com/android/wildex/model/animal/AnimalRepository.kt
@@ -1,0 +1,16 @@
+package com.android.wildex.model.animal
+
+import com.android.wildex.model.utils.Id
+
+/** Represents a repository that manages Animals. */
+interface AnimalRepository {
+
+  /** Retrieves a specific Animal item by its unique identifier. */
+  suspend fun getAnimal(animalId: Id): Animal
+
+  /** Retrieves a list of all Animal items in the repository. */
+  suspend fun getAllAnimals(): List<Animal>
+
+  /** Adds a new Animal item to the repository. */
+  suspend fun addAnimal(animal: Animal)
+}

--- a/app/src/main/java/com/android/wildex/model/animal/AnimalRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/wildex/model/animal/AnimalRepositoryFirestore.kt
@@ -1,0 +1,77 @@
+package com.android.wildex.model.animal
+
+import android.util.Log
+import com.android.wildex.model.utils.Id
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+const val ANIMAL_COLLECTION_PATH = "animals"
+
+class AnimalRepositoryFirestore(private val db: FirebaseFirestore) : AnimalRepository {
+
+  override suspend fun getAnimal(animalId: Id): Animal {
+    val doc = db.collection(ANIMAL_COLLECTION_PATH).document(animalId).get().await()
+    require(doc.exists()) { "Animal with given Id $animalId not found" }
+    return convertToAnimal(doc)
+        ?: throw IllegalArgumentException("Animal with given Id $animalId not found")
+  }
+
+  override suspend fun getAllAnimals(): List<Animal> {
+    val collection = db.collection(ANIMAL_COLLECTION_PATH).get().await()
+    val docs = collection.documents
+    if (docs.isEmpty()) {
+      Log.w("AnimalRepositoryFirestore", "No animals found in the collection.")
+      return emptyList()
+    }
+    return docs.mapNotNull { convertToAnimal(it) }
+  }
+
+  override suspend fun addAnimal(animal: Animal) {
+    if (animalExists(animal.name)) return
+
+    val documentRef = db.collection(ANIMAL_COLLECTION_PATH).document(animal.animalId)
+    val documentSnapshot = documentRef.get().await()
+
+    if (documentSnapshot.exists()) {
+      throw IllegalArgumentException(
+          "AnimalRepositoryFirestore: An animal with ID '${animal.animalId}' already exists.")
+    }
+
+    documentRef.set(animal).await()
+  }
+
+  private fun convertToAnimal(doc: DocumentSnapshot): Animal? {
+    return try {
+      val animalId = doc.id
+      val pictureURL = doc.getString("pictureURL") ?: throwMissingFieldException("pictureURL")
+      val name = doc.getString("name") ?: throwMissingFieldException("name")
+      val species = doc.getString("species") ?: throwMissingFieldException("species")
+      val description = doc.getString("description") ?: throwMissingFieldException("description")
+
+      Animal(
+          animalId = animalId,
+          pictureURL = pictureURL,
+          name = name,
+          species = species,
+          description = description)
+    } catch (e: Exception) {
+      Log.e("AnimalRepositoryFirestore", "Error converting document to Animal", e)
+      null
+    }
+  }
+
+  private fun throwMissingFieldException(field: String): Nothing {
+    throw IllegalArgumentException("Missing required field in AnimalRepository: $field")
+  }
+
+  private suspend fun animalExists(name: String): Boolean {
+    return try {
+      val snapshot = db.collection(ANIMAL_COLLECTION_PATH).whereEqualTo("name", name).get().await()
+      !snapshot.isEmpty
+    } catch (e: Exception) {
+      Log.e("AnimalRepositoryFirestore", "Error checking if animal exists", e)
+      false
+    }
+  }
+}

--- a/app/src/main/java/com/android/wildex/model/animaldetector/AnimalInfoRepository.kt
+++ b/app/src/main/java/com/android/wildex/model/animaldetector/AnimalInfoRepository.kt
@@ -3,7 +3,7 @@ package com.android.wildex.model.animaldetector
 import android.content.Context
 import android.net.Uri
 
-interface AnimalRepository {
+interface AnimalInfoRepository {
   suspend fun detectAnimal(context: Context, imageUri: Uri): List<AnimalDetectResponse>
 
   suspend fun getAnimalDescription(animalName: String): String?

--- a/app/src/main/java/com/android/wildex/model/animaldetector/AnimalRepositoryHttp.kt
+++ b/app/src/main/java/com/android/wildex/model/animaldetector/AnimalRepositoryHttp.kt
@@ -30,7 +30,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
  *
  * @property client The OkHttpClient instance used for making HTTP requests.
  */
-class AnimalRepositoryHttp(val client: OkHttpClient) : AnimalRepository {
+class AnimalRepositoryHttp(val client: OkHttpClient) : AnimalInfoRepository {
   private val adApikey = BuildConfig.ANIMALDETECT_API_KEY
 
   private val hfApikey = BuildConfig.HUGGINGFACE_API_KEY

--- a/app/src/main/java/com/android/wildex/ui/camera/CameraScreenViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/camera/CameraScreenViewModel.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import com.android.wildex.model.RepositoryProvider
 import com.android.wildex.model.animaldetector.AnimalDetectResponse
-import com.android.wildex.model.animaldetector.AnimalRepository
+import com.android.wildex.model.animaldetector.AnimalInfoRepository
 import com.android.wildex.model.social.Post
 import com.android.wildex.model.social.PostsRepository
 import com.android.wildex.model.utils.Id
@@ -25,7 +25,7 @@ data class CameraUiState(
 
 class CameraScreenViewModel(
     private val postsRepository: PostsRepository = RepositoryProvider.postRepository,
-    private val animalRepository: AnimalRepository = RepositoryProvider.animalRepository,
+    private val animalRepository: AnimalInfoRepository = RepositoryProvider.animalInfoRepository,
     // private val collectionRepository: CollectionRepository =
     // RepositoryProvider.collectionRepository,
     private val currentUserId: Id? = Firebase.auth.uid,


### PR DESCRIPTION
## Description
This pull request introduces an animal repository by adding an interface and a firestore implementation. The repository is necessary for view models like those of the animal information, the collection, the post details and the post creation. Unlike some of the other repositories, we do not use a `getNewAnimalId` method from firestore to create the id of an item, but rather use that which will be created from the animal detetct database. 

Note: Some refactoring changes were necessary to avoid confusion with regards to the `AnimalRepository` for the `Animal` class and the `AnimalInfoRepository` for the `AnimalDetect` functionality.

-Added `AnimalRepository.kt`, `AnimalRepositoryFirestore.kt` and `AnimalRepositoryFirestoreTest.kt`
-Refactored old `AnimalDetectRepository.kt` (that temporarly was `AnimalRepository.kt`) to `AnimalInfoRepository.kt`
-Modified several files to include these new changes

## Related issues
Closes #117 

## Trade-offs or known limitations
-No `editAnimal` or `deleteAnimal` methods are implemented, as this doesn't make sense for now. This may change in the future

## How to Test
Laucnh firebase emualtors (only firestore necessary) and run `AnimalRepositoryFirestoreTest.kt`