### PR TITLE
bugfix: make assignee nullable

### DIFF
--- a/app/src/androidTest/java/com/android/wildex/utils/LocalRepositories.kt
+++ b/app/src/androidTest/java/com/android/wildex/utils/LocalRepositories.kt
@@ -2,6 +2,8 @@ package com.android.wildex.utils
 
 import com.android.wildex.model.animal.Animal
 import com.android.wildex.model.animal.AnimalRepository
+import com.android.wildex.model.report.Report
+import com.android.wildex.model.report.ReportRepository
 import com.android.wildex.model.social.Comment
 import com.android.wildex.model.social.CommentRepository
 import com.android.wildex.model.social.Like
@@ -187,11 +189,53 @@ object LocalRepositories {
     }
   }
 
+  open class ReportRepositoryImpl(private val currentUserId: Id = "currentUserId-1") :
+      ReportRepository, ClearableRepository {
+
+    val listOfReports = mutableListOf<Report>()
+
+    init {
+      clear()
+    }
+
+    override fun getNewReportId(): String = "newReportId"
+
+    override suspend fun getAllReports(): List<Report> = listOfReports
+
+    override suspend fun getAllReportsByAuthor(authorId: Id): List<Report> =
+        listOfReports.filter { it.authorId == authorId }
+
+    override suspend fun getAllReportsByAssignee(assigneeId: Id?): List<Report> =
+        listOfReports.filter { it.assigneeId == assigneeId }
+
+    override suspend fun getReport(reportId: Id): Report =
+        listOfReports.find { it.reportId == reportId }!!
+
+    override suspend fun addReport(report: Report) {
+      listOfReports.add(report)
+    }
+
+    override suspend fun editReport(reportId: Id, newValue: Report) {
+      listOfReports.removeIf { it.reportId == reportId }
+      listOfReports.add(newValue)
+    }
+
+    override suspend fun deleteReport(reportId: Id) {
+      listOfReports.removeIf { it.reportId == reportId }
+    }
+
+    override fun clear() {
+      listOfReports.clear()
+    }
+  }
+
   val postsRepository: PostsRepository = PostsRepositoryImpl()
   val likeRepository: LikeRepository = LikeRepositoryImpl()
   val userRepository: UserRepository = UserRepositoryImpl()
   val commentRepository: CommentRepository = CommentRepositoryImpl()
   val animalRepository: AnimalRepository = AnimalRepositoryImpl()
+
+  val reportRepository: ReportRepository = ReportRepositoryImpl()
 
   fun clearAll() {
     (postsRepository as ClearableRepository).clear()
@@ -199,5 +243,6 @@ object LocalRepositories {
     (userRepository as ClearableRepository).clear()
     (commentRepository as ClearableRepository).clear()
     (animalRepository as ClearableRepository).clear()
+    (reportRepository as ClearableRepository).clear()
   }
 }

--- a/app/src/main/java/com/android/wildex/model/RepositoryProvider.kt
+++ b/app/src/main/java/com/android/wildex/model/RepositoryProvider.kt
@@ -9,6 +9,8 @@ import com.android.wildex.model.animaldetector.AnimalInfoRepository
 import com.android.wildex.model.animaldetector.AnimalRepositoryHttp
 import com.android.wildex.model.authentication.AuthRepository
 import com.android.wildex.model.authentication.AuthRepositoryFirebase
+import com.android.wildex.model.report.ReportRepository
+import com.android.wildex.model.report.ReportRepositoryFirestore
 import com.android.wildex.model.social.CommentRepository
 import com.android.wildex.model.social.CommentRepositoryFirestore
 import com.android.wildex.model.social.LikeRepository
@@ -31,6 +33,8 @@ object RepositoryProvider {
   val postRepository: PostsRepository by lazy { PostsRepositoryFirestore(Firebase.firestore) }
   val userRepository: UserRepository by lazy { UserRepositoryFirestore(Firebase.firestore) }
   val likeRepository: LikeRepository by lazy { LikeRepositoryFirestore(Firebase.firestore) }
+  val reportRepository: ReportRepository by lazy { ReportRepositoryFirestore(Firebase.firestore) }
+
   val commentRepository: CommentRepository by lazy {
     CommentRepositoryFirestore(Firebase.firestore)
   }

--- a/app/src/main/java/com/android/wildex/model/report/Report.kt
+++ b/app/src/main/java/com/android/wildex/model/report/Report.kt
@@ -24,7 +24,7 @@ data class Report(
     val date: Timestamp,
     val description: String,
     val authorId: Id,
-    val assigneeId: Id,
+    val assigneeId: Id?,
     val status: ReportStatus,
 )
 

--- a/app/src/main/java/com/android/wildex/model/report/ReportRepository.kt
+++ b/app/src/main/java/com/android/wildex/model/report/ReportRepository.kt
@@ -15,7 +15,7 @@ interface ReportRepository {
   suspend fun getAllReportsByAuthor(authorId: Id): List<Report>
 
   /** Retrieves all Reports items associated with a specific assignee. */
-  suspend fun getAllReportsByAssignee(assigneeId: Id): List<Report>
+  suspend fun getAllReportsByAssignee(assigneeId: Id?): List<Report>
 
   /** Retrieves a specific Report item by its unique identifier. */
   suspend fun getReport(reportId: Id): Report

--- a/app/src/main/java/com/android/wildex/model/report/ReportRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/wildex/model/report/ReportRepositoryFirestore.kt
@@ -58,12 +58,13 @@ class ReportRepositoryFirestore(private val db: FirebaseFirestore) : ReportRepos
   }
 
   /**
-   * Retrieves all Reports items associated with a specific assignee.
+   * Retrieves all Reports items associated with a specific assignee. If given a null assigneeId, it
+   * retrieves all unassigned reports.
    *
    * @param assigneeId The ID of the assignee of the reports to retrieve.
    * @return A list of [Report] items associated with the specified assignee.
    */
-  override suspend fun getAllReportsByAssignee(assigneeId: Id): List<Report> {
+  override suspend fun getAllReportsByAssignee(assigneeId: Id?): List<Report> {
     return collection
         .whereEqualTo(ReportsFields.ASSIGNEE_ID, assigneeId)
         .get()
@@ -171,9 +172,7 @@ class ReportRepositoryFirestore(private val db: FirebaseFirestore) : ReportRepos
       val authorId =
           document.getString(ReportsFields.AUTHOR_ID)
               ?: throwMissingFieldException(ReportsFields.AUTHOR_ID)
-      val assigneeId =
-          document.getString(ReportsFields.ASSIGNEE_ID)
-              ?: throwMissingFieldException(ReportsFields.ASSIGNEE_ID)
+      val assigneeId = document.getString(ReportsFields.ASSIGNEE_ID)
       val statusData =
           document.getString(ReportsFields.STATUS)
               ?: throwMissingFieldException(ReportsFields.STATUS)


### PR DESCRIPTION
This PR makes the `assigneeId` field **nullable** to handle unassigned reports.
I also took the opportunity to **instantiate `reportRepository` in `RepositoryProvider`** and add a **local implementation** of it in `LocalRepositories`, consistent with the other repositories.
