### PR TITLE
feat: implement EditProfileScreen (#68)

### DIFF
--- a/app/src/androidTest/java/com/android/wildex/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/profile/EditProfileScreenTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
@@ -75,14 +74,25 @@ class EditProfileScreenTest {
     composeRule.setContent { EditProfileScreen(editScreenViewModel = vm, isNewUser = true) }
     composeRule.waitForIdle()
 
-    composeRule.onNodeWithTag(EditProfileScreenTestTags.DROPDOWN_COUNTRY).performClick()
+    val initialCountry = vm.uiState.value.country
     composeRule
-        .onNodeWithText("United States", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .performClick()
+        .onNodeWithTag(EditProfileScreenTestTags.DROPDOWN_COUNTRY)
+        .assertTextContains(initialCountry, substring = false)
+
+    composeRule.onNodeWithTag(EditProfileScreenTestTags.DROPDOWN_COUNTRY).performClick()
+    val items =
+        composeRule.onAllNodesWithTag(
+            EditProfileScreenTestTags.COUNTRY_ELEMENT, useUnmergedTree = true)
+    items.assertCountEquals(items.fetchSemanticsNodes().size)
+    items[0].performClick()
     composeRule.waitForIdle()
 
-    composeRule.onNodeWithText("United States", useUnmergedTree = true).assertIsDisplayed()
+    val newCountry = vm.uiState.value.country
+    Assert.assertNotEquals(initialCountry, newCountry)
+
+    composeRule
+        .onNodeWithTag(EditProfileScreenTestTags.DROPDOWN_COUNTRY)
+        .assertTextContains(newCountry, substring = false)
   }
 
   @Test
@@ -149,7 +159,7 @@ class EditProfileScreenTest {
     }
     composeRule.waitForIdle()
 
-    composeRule.onNodeWithText("Save").performClick()
+    composeRule.onNodeWithTag(EditProfileScreenTestTags.SAVE).performClick()
     Assert.assertEquals(1, saved)
   }
 }

--- a/app/src/main/java/com/android/wildex/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/android/wildex/ui/profile/EditProfileScreen.kt
@@ -1,20 +1,27 @@
 package com.android.wildex.ui.profile
 
+import android.net.Uri
+import android.widget.Toast
+import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.SaveAlt
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -37,12 +44,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.wildex.ui.LoadingFail
+import com.android.wildex.ui.LoadingScreen
 import com.mapbox.maps.extension.style.expressions.dsl.generated.color
+import java.util.Locale
+import kotlin.collections.get
 
 object EditProfileScreenTestTags {
   const val GO_BACK = "edit_profile_screen_go_back_button"
@@ -50,7 +62,6 @@ object EditProfileScreenTestTags {
   const val INPUT_SURNAME = "edit_profile_screen_input_surname"
   const val INPUT_USERNAME = "edit_profile_screen_input_username"
   const val INPUT_DESCRIPTION = "edit_profile_screen_input_description"
-  const val INPUT_COUNTRY = "edit_profile_screen_input_country"
   const val DROPDOWN_COUNTRY = "edit_profile_screen_dropdown_country"
   const val COUNTRY_ELEMENT = "edit_profile_screen_country_element_"
   const val CHANGE_PROFILE_PICTURE = "edit_profile_screen_change_profile_picture_button"
@@ -68,11 +79,20 @@ fun EditProfileScreen(
 ) {
   LaunchedEffect(Unit) { editScreenViewModel.loadUIState() }
   val uiState by editScreenViewModel.uiState.collectAsState()
-  val errorMsg = uiState.errorMsg
-  // State for dropdown visibility
-  var showDropdown by remember { mutableStateOf(false) }
-
-  val countryList = uiState.countryList
+  val context = LocalContext.current
+  val userLocale = context.resources.configuration.locales[0]
+  val countryNames =
+      remember(userLocale) {
+        Locale.getISOCountries()
+            .map { code -> Locale("", code).getDisplayCountry(userLocale) }
+            .sorted()
+      }
+  LaunchedEffect(uiState.errorMsg) {
+    uiState.errorMsg?.let {
+      Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+      editScreenViewModel.clearErrorMsg()
+    }
+  }
 
   // Launcher for image picker
   val pickImageLauncher =
@@ -85,152 +105,174 @@ fun EditProfileScreen(
       modifier = Modifier.fillMaxSize(),
       topBar = { EditProfileTopBar(onGoBack) },
   ) { pd ->
-    Column(
-        modifier = Modifier.fillMaxSize().padding(pd).padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)) {
-          // Name Input
-          OutlinedTextField(
-              value = uiState.name,
-              onValueChange = { editScreenViewModel.setName(it) },
-              label = { Text("Name") },
-              placeholder = { Text("Name") },
-              isError = uiState.invalidNameMsg != null,
-              supportingText = {
-                uiState.invalidNameMsg?.let {
-                  Text(it, modifier = Modifier.testTag(EditProfileScreenTestTags.ERROR_MESSAGE))
-                }
-              },
-              modifier = Modifier.fillMaxWidth().testTag(EditProfileScreenTestTags.INPUT_NAME))
-          // Surname Input
-          OutlinedTextField(
-              value = uiState.surname,
-              onValueChange = { editScreenViewModel.setSurname(it) },
-              label = { Text("Surname") },
-              placeholder = { Text("Surname") },
-              isError = uiState.invalidSurnameMsg != null,
-              supportingText = {
-                uiState.invalidSurnameMsg?.let {
-                  Text(it, modifier = Modifier.testTag(EditProfileScreenTestTags.ERROR_MESSAGE))
-                }
-              },
-              modifier = Modifier.fillMaxWidth().testTag(EditProfileScreenTestTags.INPUT_SURNAME))
-          // User Input
-          OutlinedTextField(
-              value = uiState.username,
-              onValueChange = { editScreenViewModel.setUsername(it) },
-              label = { Text("Username") },
-              placeholder = { Text("Username") },
-              isError = uiState.invalidUsernameMsg != null,
-              supportingText = {
-                uiState.invalidUsernameMsg?.let {
-                  Text(it, modifier = Modifier.testTag(EditProfileScreenTestTags.ERROR_MESSAGE))
-                }
-              },
-              modifier = Modifier.fillMaxWidth().testTag(EditProfileScreenTestTags.INPUT_USERNAME))
-          // Description Input
-          OutlinedTextField(
-              value = uiState.description,
-              onValueChange = { editScreenViewModel.setDescription(it) },
-              label = { Text("Description") },
-              placeholder = { Text("Description") },
-              modifier =
-                  Modifier.fillMaxWidth().testTag(EditProfileScreenTestTags.INPUT_DESCRIPTION))
-          // Country Input with dropdown
+    when {
+      uiState.isError -> LoadingFail()
+      uiState.isLoading -> LoadingScreen()
+      else ->
+          EditView(
+              editScreenViewModel = editScreenViewModel,
+              onSave = onSave,
+              isNewUser = isNewUser,
+              pd = pd,
+              uiState = uiState,
+              countryNames = countryNames,
+              cs = cs,
+              pickImageLauncher = pickImageLauncher)
+    }
+  }
+}
 
-          Box(modifier = Modifier.fillMaxWidth()) {
-            TextButton(
-                onClick = { showDropdown = true },
-                modifier =
-                    Modifier.align(Alignment.Center)
-                        .testTag(EditProfileScreenTestTags.DROPDOWN_COUNTRY)) {
-                  Text(text = uiState.country)
-                }
-
-            // Dropdown to show location suggestions
-            DropdownMenu(
-                expanded = showDropdown && countryList.isNotEmpty(),
-                onDismissRequest = { showDropdown = false },
-                properties = PopupProperties(focusable = false),
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .heightIn(
-                            max = 200.dp) // Set max height to make it scrollable if more than 3
-                // items
-                ) {
-                  countryList.forEach { country ->
-                    DropdownMenuItem(
-                        text = {
-                          Text(
-                              text =
-                                  country.take(30) +
-                                      if (country.length > 30) "..."
-                                      else "", // Limit name length and add ellipsis
-                              maxLines = 1, // Ensure name doesn't overflow
-                          )
-                        },
-                        onClick = {
-                          // Update country
-                          editScreenViewModel.setCountry(country)
-                          showDropdown = false // Close dropdown on selection
-                        },
-                        modifier =
-                            Modifier.padding(8.dp)
-                                .testTag(
-                                    EditProfileScreenTestTags
-                                        .COUNTRY_ELEMENT) // Add padding for better
-                        // separation
-                        )
-                    HorizontalDivider(
-                        Modifier,
-                        DividerDefaults.Thickness,
-                        DividerDefaults.color) // Separate items with a divider
-                  }
-
-                  if (countryList.size > 3) {
-                    DropdownMenuItem(
-                        text = { Text("More...") },
-                        onClick = { /* Nothing currently */},
-                        modifier = Modifier.padding(8.dp))
-                  }
-                }
-          }
-          Button(
-              modifier =
-                  Modifier.fillMaxWidth().testTag(EditProfileScreenTestTags.CHANGE_PROFILE_PICTURE),
-              onClick = {
-                // Opens image picker
-                pickImageLauncher.launch("image/*")
-              },
-              colors =
-                  ButtonDefaults.buttonColors(
-                      containerColor = cs.secondary,
-                      contentColor = cs.onSecondary,
-                  )) {
-                Text(text = "Change profile picture")
+@Composable
+fun EditView(
+    editScreenViewModel: EditProfileViewModel = viewModel(),
+    onSave: () -> Unit = {},
+    isNewUser: Boolean = false,
+    pd: PaddingValues = PaddingValues(0.dp),
+    uiState: EditProfileUIState,
+    countryNames: List<String> = emptyList(),
+    cs: ColorScheme,
+    pickImageLauncher: ManagedActivityResultLauncher<String, Uri?>
+) {
+  // State for dropdown visibility
+  var showDropdown by remember { mutableStateOf(false) }
+  Column(
+      modifier =
+          Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(pd).padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        // Name Input
+        OutlinedTextField(
+            value = uiState.name,
+            onValueChange = { editScreenViewModel.setName(it) },
+            label = { Text("Name") },
+            placeholder = { Text("Name") },
+            isError = uiState.invalidNameMsg != null,
+            supportingText = {
+              uiState.invalidNameMsg?.let {
+                Text(it, modifier = Modifier.testTag(EditProfileScreenTestTags.ERROR_MESSAGE))
               }
-          Button(
-              onClick = {
-                if (isNewUser) {
-                  onSave()
-                }
-                editScreenViewModel.saveProfileChanges()
-              },
-              colors =
-                  ButtonDefaults.buttonColors(
-                      containerColor = cs.secondary,
-                      contentColor = cs.onSecondary,
-                  )) {
-                Row {
-                  Icon(
-                      imageVector = Icons.Filled.SaveAlt,
-                      contentDescription = "Save",
-                      tint = cs.onSecondary,
-                  )
-                  Text(text = "Save")
+            },
+            modifier = Modifier.fillMaxWidth().testTag(EditProfileScreenTestTags.INPUT_NAME))
+        // Surname Input
+        OutlinedTextField(
+            value = uiState.surname,
+            onValueChange = { editScreenViewModel.setSurname(it) },
+            label = { Text("Surname") },
+            placeholder = { Text("Surname") },
+            isError = uiState.invalidSurnameMsg != null,
+            supportingText = {
+              uiState.invalidSurnameMsg?.let {
+                Text(it, modifier = Modifier.testTag(EditProfileScreenTestTags.ERROR_MESSAGE))
+              }
+            },
+            modifier = Modifier.fillMaxWidth().testTag(EditProfileScreenTestTags.INPUT_SURNAME))
+        // User Input
+        OutlinedTextField(
+            value = uiState.username,
+            onValueChange = { editScreenViewModel.setUsername(it) },
+            label = { Text("Username") },
+            placeholder = { Text("Username") },
+            isError = uiState.invalidUsernameMsg != null,
+            supportingText = {
+              uiState.invalidUsernameMsg?.let {
+                Text(it, modifier = Modifier.testTag(EditProfileScreenTestTags.ERROR_MESSAGE))
+              }
+            },
+            modifier = Modifier.fillMaxWidth().testTag(EditProfileScreenTestTags.INPUT_USERNAME))
+        // Description Input
+        OutlinedTextField(
+            value = uiState.description,
+            onValueChange = { editScreenViewModel.setDescription(it) },
+            label = { Text("Description") },
+            placeholder = { Text("Description") },
+            modifier = Modifier.fillMaxWidth().testTag(EditProfileScreenTestTags.INPUT_DESCRIPTION))
+        // Country Input with dropdown
+
+        Box(modifier = Modifier.fillMaxWidth()) {
+          TextButton(
+              onClick = { showDropdown = true },
+              modifier =
+                  Modifier.align(Alignment.Center)
+                      .testTag(EditProfileScreenTestTags.DROPDOWN_COUNTRY)) {
+                Text(text = uiState.country)
+              }
+
+          // Dropdown to show location suggestions
+          DropdownMenu(
+              expanded = showDropdown && countryNames.isNotEmpty(),
+              onDismissRequest = { showDropdown = false },
+              properties = PopupProperties(focusable = false),
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .heightIn(max = 200.dp) // Set max height to make it scrollable if more than 3
+              // items
+              ) {
+                countryNames.forEach { country ->
+                  DropdownMenuItem(
+                      text = {
+                        Text(
+                            text =
+                                country.take(30) +
+                                    if (country.length > 30) "..."
+                                    else "", // Limit name length and add ellipsis
+                            maxLines = 1, // Ensure name doesn't overflow
+                        )
+                      },
+                      onClick = {
+                        // Update country
+                        editScreenViewModel.setCountry(country)
+                        showDropdown = false // Close dropdown on selection
+                      },
+                      modifier =
+                          Modifier.padding(8.dp)
+                              .testTag(
+                                  EditProfileScreenTestTags
+                                      .COUNTRY_ELEMENT) // Add padding for better
+                      // separation
+                      )
+                  HorizontalDivider(
+                      Modifier,
+                      DividerDefaults.Thickness,
+                      DividerDefaults.color) // Separate items with a divider
                 }
               }
         }
-  }
+        Button(
+            modifier =
+                Modifier.fillMaxWidth().testTag(EditProfileScreenTestTags.CHANGE_PROFILE_PICTURE),
+            onClick = {
+              // Opens image picker
+              pickImageLauncher.launch("image/*")
+            },
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = cs.secondary,
+                    contentColor = cs.onSecondary,
+                )) {
+              Text(text = "Change profile picture")
+            }
+        Button(
+            onClick = {
+              editScreenViewModel.saveProfileChanges()
+              if (isNewUser) {
+                onSave()
+              }
+            },
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = cs.secondary,
+                    contentColor = cs.onSecondary,
+                ),
+            modifier = Modifier.testTag(EditProfileScreenTestTags.SAVE)) {
+              Row {
+                Icon(
+                    imageVector = Icons.Filled.SaveAlt,
+                    contentDescription = "Save",
+                    tint = cs.onSecondary,
+                )
+                Text(text = "Save")
+              }
+            }
+      }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/android/wildex/ui/profile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/profile/EditProfileViewModel.kt
@@ -23,22 +23,6 @@ data class EditProfileUIState(
     val username: String = "",
     val description: String = "",
     val country: String = "Switzerland",
-    val countryList: List<String> =
-        listOf(
-            "Switzerland",
-            "United States",
-            "Canada",
-            "United Kingdom",
-            "Germany",
-            "France",
-            "Italy",
-            "Spain",
-            "Australia",
-            "India",
-            "China",
-            "Japan",
-        ),
-    val profileImageUrl: URL = "",
     val isLoading: Boolean = false,
     val errorMsg: String? = null,
     val isError: Boolean = false,
@@ -96,7 +80,6 @@ class EditProfileViewModel(
               username = user.username,
               description = user.bio,
               country = user.country,
-              profileImageUrl = user.profilePictureURL,
               isLoading = false,
               errorMsg = null,
               isError = false,
@@ -116,9 +99,7 @@ class EditProfileViewModel(
     _uiState.value = _uiState.value.copy(errorMsg = msg)
   }
 
-  fun saveProfileChanges(
-      profileImageUri: Uri? = null,
-  ) {
+  fun saveProfileChanges() {
     if (!_uiState.value.isValid) {
       setErrorMsg("At least one field is not valid")
       return
@@ -127,11 +108,10 @@ class EditProfileViewModel(
       try {
         _uiState.value = _uiState.value.copy(isLoading = true, isError = false)
         val user = userRepository.getUser(currentUserId)
-        val effectiveUri = profileImageUri ?: pendingProfileImageUri
         val newURL: URL
-        if (effectiveUri != null) {
+        if (pendingProfileImageUri != null) {
           newURL =
-              storageRepository.uploadUserProfilePicture(currentUserId, effectiveUri)
+              storageRepository.uploadUserProfilePicture(currentUserId, pendingProfileImageUri!!)
                   ?: user.profilePictureURL
         } else {
           newURL = user.profilePictureURL
@@ -191,10 +171,6 @@ class EditProfileViewModel(
 
   fun setCountry(country: String) {
     _uiState.value = _uiState.value.copy(country = country)
-  }
-
-  fun setNewProfileImageUrl(url: URL) {
-    _uiState.value = _uiState.value.copy(profileImageUrl = url)
   }
 
   fun setNewProfileImageUri(uri: Uri?) {

--- a/app/src/test/java/com/android/wildex/ui/profile/EditProfileViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/profile/EditProfileViewModelTest.kt
@@ -62,7 +62,6 @@ class EditProfileViewModelTest {
     Assert.assertEquals("", s.username)
     Assert.assertEquals("", s.description)
     Assert.assertEquals("Switzerland", s.country)
-    Assert.assertEquals("", s.profileImageUrl)
     Assert.assertFalse(s.isLoading)
     Assert.assertFalse(s.isError)
     Assert.assertNull(s.errorMsg)
@@ -82,7 +81,6 @@ class EditProfileViewModelTest {
       Assert.assertEquals(u1.username, s.username)
       Assert.assertEquals(u1.bio, s.description)
       Assert.assertEquals(u1.country, s.country)
-      Assert.assertEquals(u1.profilePictureURL, s.profileImageUrl)
       Assert.assertFalse(s.isLoading)
       Assert.assertFalse(s.isError)
       Assert.assertNull(s.errorMsg)
@@ -144,15 +142,15 @@ class EditProfileViewModelTest {
       viewModel.setSurname("B")
       viewModel.setUsername("C")
       viewModel.setDescription("D")
-      viewModel.setNewProfileImageUrl("ignored")
 
       val anyUri = mockk<Uri>(relaxed = true)
+      viewModel.setNewProfileImageUri(anyUri)
 
       coEvery { userRepository.getUser("uid-1") } returns u1
       coEvery { storageRepository.uploadUserProfilePicture("uid-1", any()) } returns "newPic"
       coEvery { userRepository.editUser(any(), any()) } returns Unit
 
-      viewModel.saveProfileChanges(anyUri)
+      viewModel.saveProfileChanges()
       advanceUntilIdle()
 
       val captured = slot<User>()
@@ -180,12 +178,13 @@ class EditProfileViewModelTest {
       viewModel.setDescription("D")
 
       val anyUri = mockk<Uri>(relaxed = true)
+      viewModel.setNewProfileImageUri(anyUri)
 
       coEvery { userRepository.getUser("uid-1") } returns u1
       coEvery { storageRepository.uploadUserProfilePicture("uid-1", any()) } throws
           RuntimeException("x")
 
-      viewModel.saveProfileChanges(anyUri)
+      viewModel.saveProfileChanges()
       advanceUntilIdle()
 
       val s = viewModel.uiState.value
@@ -300,12 +299,13 @@ class EditProfileViewModelTest {
       viewModel.setDescription("D")
 
       val anyUri = mockk<Uri>(relaxed = true)
+      viewModel.setNewProfileImageUri(anyUri)
 
       coEvery { userRepository.getUser("uid-1") } returns u1
       coEvery { storageRepository.uploadUserProfilePicture("uid-1", any()) } returns null
       coEvery { userRepository.editUser(any(), any()) } returns Unit
 
-      viewModel.saveProfileChanges(anyUri)
+      viewModel.saveProfileChanges()
       advanceUntilIdle()
 
       val captured = slot<User>()


### PR DESCRIPTION
## Description
This PR implements the EditProfile screen and updates its viewModel adding useful functions. It includes tests for both files.
The screen purpose is to modify the current user's informations, and save them in the online repo. They can change their names, bio, country and profile picture.

* Add ability to access the phone's pictures to upload a new profile picture.
* Text fields display an error when upload conditions aren't met.
* The save button uploads all modifications to the online repository and depending on wether it's the first time signin in or not, will bring back to the home screen or stay there if it's not a new user.
* When the screen loads, the text fields are already filled with the user's infos pulled from repository.
* The screen is scrollable to adapt to any screen size or shape.
* It shows a loading screen when loading and an error screen if something went wrong.

## Related issues
Closes #68 

## Trade-offs or known limitations
Currently, navigation doesn't take this screen into account, so it is not accessible yet.

## How to test
* Run EditProfileScreenTest
* (To check updated tests) Run EditProfileViewModelTest

## Notes:
* AI assistant was used to help debugging tests