### PR TITLE
fix: Rename field in the Comment data class

### DIFF
--- a/app/src/androidTest/java/com/android/wildex/model/comment/CommentRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/model/comment/CommentRepositoryFirestoreTest.kt
@@ -18,14 +18,14 @@ class CommentRepositoryFirestoreTest : FirestoreTest(COMMENTS_COLLECTION_PATH) {
   @Test
   fun getNewCommentIdReturnsUniqueIDs() = runTest {
     val numberIds = 100
-    val postIds = (0 until numberIds).toSet().map { repository.getNewCommentId() }.toSet()
+    val commentIds = (0 until numberIds).toSet().map { repository.getNewCommentId() }.toSet()
 
-    assertEquals(postIds.size, numberIds)
+    assertEquals(commentIds.size, numberIds)
   }
 
   @Test
   fun getAllCommentsByPostWhenNoPostsExist() = runTest {
-    val postId = comment1.postId
+    val postId = comment1.parentId
     val comments = repository.getAllCommentsByPost(postId)
 
     assertTrue(comments.isEmpty())
@@ -36,7 +36,7 @@ class CommentRepositoryFirestoreTest : FirestoreTest(COMMENTS_COLLECTION_PATH) {
     repository.addComment(comment1)
     repository.addComment(comment2)
 
-    val postId = "noPost"
+    val postId = "noParent"
     val comments = repository.getAllCommentsByPost(postId)
 
     assertTrue(comments.isEmpty())
@@ -48,16 +48,71 @@ class CommentRepositoryFirestoreTest : FirestoreTest(COMMENTS_COLLECTION_PATH) {
     repository.addComment(comment2)
 
     for (i in 1..2) {
-      val postId =
+      val parentId =
           when (i) {
-            1 -> comment1.postId
-            2 -> comment2.postId
+            1 -> comment1.parentId
+            2 -> comment2.parentId
             else -> throw IllegalStateException("Unexpected comment index")
           }
-      val comments = repository.getAllCommentsByPost(postId)
 
-      assertEquals(1, comments.size)
-      assertTrue(comments.all { it.postId == postId })
+      val comments = repository.getAllCommentsByPost(parentId)
+
+      when (i) {
+        1 -> {
+          assertEquals(1, comments.size)
+          assertTrue(comments.all { it.parentId == parentId })
+        }
+        2 -> {
+          assertTrue(comments.isEmpty())
+        }
+        else -> throw IllegalStateException("Unexpected comment index")
+      }
+    }
+  }
+
+  @Test
+  fun getAllCommentsByReportWhenNoReportsExist() = runTest {
+    val reportId = comment2.parentId
+    val comments = repository.getAllCommentsByReport(reportId)
+
+    assertTrue(comments.isEmpty())
+  }
+
+  @Test
+  fun getAllCommentsByReportWhenNoCorrespondingReportsExist() = runTest {
+    repository.addComment(comment1)
+    repository.addComment(comment2)
+
+    val reportId = "noParent"
+    val comments = repository.getAllCommentsByReport(reportId)
+
+    assertTrue(comments.isEmpty())
+  }
+
+  @Test
+  fun getAllCommentsByReportWhenCorrespondingReportsExist() = runTest {
+    repository.addComment(comment1)
+    repository.addComment(comment2)
+
+    for (i in 1..2) {
+      val parentId =
+          when (i) {
+            1 -> comment1.parentId
+            2 -> comment2.parentId
+            else -> throw IllegalStateException("Unexpected comment index")
+          }
+      val comments = repository.getAllCommentsByReport(parentId)
+
+      when (i) {
+        1 -> {
+          assertTrue(comments.isEmpty())
+        }
+        2 -> {
+          assertEquals(1, comments.size)
+          assertTrue(comments.all { it.parentId == parentId })
+        }
+        else -> throw IllegalStateException("Unexpected comment index")
+      }
     }
   }
 
@@ -73,7 +128,7 @@ class CommentRepositoryFirestoreTest : FirestoreTest(COMMENTS_COLLECTION_PATH) {
 
     assert(!exceptionThrown)
 
-    val comments = repository.getAllCommentsByPost(comment1.postId)
+    val comments = repository.getAllCommentsByPost(comment1.parentId)
     assertEquals(1, comments.size)
     assertEquals(comment1, comments[0])
   }
@@ -120,13 +175,13 @@ class CommentRepositoryFirestoreTest : FirestoreTest(COMMENTS_COLLECTION_PATH) {
 
     assert(!exceptionThrown)
 
-    var comments = repository.getAllCommentsByPost(comment1.postId)
+    var comments = repository.getAllCommentsByPost(comment1.parentId)
     assertTrue(comments.isEmpty())
 
-    comments = repository.getAllCommentsByPost(comment2.postId)
+    comments = repository.getAllCommentsByReport(comment2.parentId)
     assertEquals(1, comments.size)
     assertEquals(comment1.commentId, comments[0].commentId)
-    assertEquals(comment2.postId, comments[0].postId)
+    assertEquals(comment2.parentId, comments[0].parentId)
     assertEquals(comment2.authorId, comments[0].authorId)
     assertEquals(comment2.text, comments[0].text)
     assertEquals(comment2.date, comments[0].date)
@@ -138,14 +193,14 @@ class CommentRepositoryFirestoreTest : FirestoreTest(COMMENTS_COLLECTION_PATH) {
     var exceptionThrown = false
 
     try {
-      repository.deleteAllCommentsOfPost(comment2.postId)
+      repository.deleteAllCommentsOfPost(comment2.parentId)
     } catch (e: IllegalArgumentException) {
       exceptionThrown = true
     }
 
     assert(!exceptionThrown)
 
-    val comments = repository.getAllCommentsByPost(comment2.postId)
+    val comments = repository.getAllCommentsByReport(comment2.parentId)
 
     assertEquals(1, comments.size)
     assertTrue(comments.contains(comment2))
@@ -157,14 +212,14 @@ class CommentRepositoryFirestoreTest : FirestoreTest(COMMENTS_COLLECTION_PATH) {
     var exceptionThrown = false
 
     try {
-      repository.deleteAllCommentsOfPost(comment1.postId)
+      repository.deleteAllCommentsOfPost(comment1.parentId)
     } catch (e: IllegalArgumentException) {
       exceptionThrown = true
     }
 
     assert(!exceptionThrown)
 
-    val comments = repository.getAllCommentsByPost(comment1.postId)
+    val comments = repository.getAllCommentsByPost(comment1.parentId)
 
     assertTrue(comments.isEmpty())
   }
@@ -175,14 +230,14 @@ class CommentRepositoryFirestoreTest : FirestoreTest(COMMENTS_COLLECTION_PATH) {
     var exceptionThrown = false
 
     try {
-      repository.deleteAllCommentsOfReport(comment2.postId)
+      repository.deleteAllCommentsOfReport(comment2.parentId)
     } catch (e: IllegalArgumentException) {
       exceptionThrown = true
     }
 
     assert(!exceptionThrown)
 
-    val comments = repository.getAllCommentsByPost(comment2.postId)
+    val comments = repository.getAllCommentsByReport(comment2.parentId)
 
     assertTrue(comments.isEmpty())
   }
@@ -193,14 +248,14 @@ class CommentRepositoryFirestoreTest : FirestoreTest(COMMENTS_COLLECTION_PATH) {
     var exceptionThrown = false
 
     try {
-      repository.deleteAllCommentsOfReport(comment1.postId)
+      repository.deleteAllCommentsOfReport(comment1.parentId)
     } catch (e: IllegalArgumentException) {
       exceptionThrown = true
     }
 
     assert(!exceptionThrown)
 
-    val comments = repository.getAllCommentsByPost(comment1.postId)
+    val comments = repository.getAllCommentsByPost(comment1.parentId)
 
     assertEquals(1, comments.size)
     assertTrue(comments.contains(comment1))
@@ -233,7 +288,7 @@ class CommentRepositoryFirestoreTest : FirestoreTest(COMMENTS_COLLECTION_PATH) {
 
     assert(!exceptionThrown)
 
-    val comments = repository.getAllCommentsByPost(comment1.postId)
+    val comments = repository.getAllCommentsByPost(comment1.parentId)
     assertTrue(comments.isEmpty())
   }
 

--- a/app/src/androidTest/java/com/android/wildex/ui/post/PostDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/post/PostDetailsScreenTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.performTextInput
 import com.android.wildex.model.animal.Animal
 import com.android.wildex.model.social.Comment
 import com.android.wildex.model.social.CommentRepository
+import com.android.wildex.model.social.CommentTag
 import com.android.wildex.model.social.Like
 import com.android.wildex.model.social.LikeRepository
 import com.android.wildex.model.social.Post
@@ -160,19 +161,19 @@ class PostDetailsScreenTest {
     commentRepository.addComment(
         Comment(
             commentId = "comment1",
-            postId = post.postId,
+            parentId = post.postId,
             authorId = commenter1.userId,
             text = "Amazing shot!",
             date = Timestamp.now(),
-        ))
+            tag = CommentTag.POST_COMMENT))
     commentRepository.addComment(
         Comment(
             commentId = "comment2",
-            postId = post.postId,
+            parentId = post.postId,
             authorId = commenter2.userId,
             text = "Love this!",
             date = Timestamp.now(),
-        ))
+            tag = CommentTag.POST_COMMENT))
 
     val animal =
         Animal(

--- a/app/src/androidTest/java/com/android/wildex/utils/FirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/utils/FirestoreTest.kt
@@ -165,7 +165,7 @@ open class FirestoreTest(val collectionPath: String) {
   open val comment1 =
       Comment(
           commentId = "comment1",
-          postId = "post1",
+          parentId = "parent1",
           authorId = "author1",
           text = "text1",
           date = Timestamp.fromDate(2003, 11, 21),
@@ -174,7 +174,7 @@ open class FirestoreTest(val collectionPath: String) {
   open val comment2 =
       Comment(
           commentId = "comment2",
-          postId = "post2",
+          parentId = "parent2",
           authorId = "author2",
           text = "text2",
           date = Timestamp.fromDate(2012, 12, 12),

--- a/app/src/androidTest/java/com/android/wildex/utils/LocalRepositories.kt
+++ b/app/src/androidTest/java/com/android/wildex/utils/LocalRepositories.kt
@@ -155,7 +155,10 @@ object LocalRepositories {
     override fun getNewCommentId(): String = "newCommentId"
 
     override suspend fun getAllCommentsByPost(postId: String): List<Comment> =
-        listOfComments.filter { it.postId == postId }
+        listOfComments.filter { it.parentId == postId }
+
+    override suspend fun getAllCommentsByReport(reportId: Id): List<Comment> =
+        listOfComments.filter { it.parentId == reportId }
 
     override suspend fun addComment(comment: Comment) {
       listOfComments.add(comment)

--- a/app/src/main/java/com/android/wildex/model/social/Comment.kt
+++ b/app/src/main/java/com/android/wildex/model/social/Comment.kt
@@ -7,19 +7,19 @@ import com.google.firebase.Timestamp
  * Represents a comment on a post.
  *
  * @property commentId The unique identifier for the comment.
- * @property postId The ID of the post that this comment belongs to.
+ * @property parentId The ID of the post that this comment belongs to.
  * @property authorId The ID of the user who made the comment.
  * @property text The content of the comment.
- * @property date The date and time when the comment was made. //@property tag The tag of the
- *   comment.
+ * @property date The date and time when the comment was made.
+ * @property tag The tag of the comment.
  */
 data class Comment(
     val commentId: Id,
-    val postId: Id,
+    val parentId: Id,
     val authorId: Id,
     val text: String,
     val date: Timestamp,
-    val tag: CommentTag = CommentTag.POST_COMMENT,
+    val tag: CommentTag,
 )
 
 /** Enum class representing the tag of a comment. */

--- a/app/src/main/java/com/android/wildex/model/social/CommentRepository.kt
+++ b/app/src/main/java/com/android/wildex/model/social/CommentRepository.kt
@@ -11,6 +11,9 @@ interface CommentRepository {
   /** Retrieves all Comment items associated with a specific post. */
   suspend fun getAllCommentsByPost(postId: Id): List<Comment>
 
+  /** Retrieves all Comment items associated with a specific report. */
+  suspend fun getAllCommentsByReport(reportId: Id): List<Comment>
+
   /** Adds a new Comment item to the repository. */
   suspend fun addComment(comment: Comment)
 

--- a/app/src/main/java/com/android/wildex/model/social/CommentRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/wildex/model/social/CommentRepositoryFirestore.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.tasks.await
 private const val COMMENTS_COLLECTION_PATH = "comments"
 
 private object CommentsFields {
-  const val POST_ID = "postId"
+  const val PARENT_ID = "parentId"
   const val AUTHOR_ID = "authorId"
   const val TEXT = "text"
   const val DATE = "date"
@@ -38,7 +38,24 @@ class CommentRepositoryFirestore(private val db: FirebaseFirestore) : CommentRep
    */
   override suspend fun getAllCommentsByPost(postId: String): List<Comment> {
     return collection
-        .whereEqualTo(CommentsFields.POST_ID, postId)
+        .whereEqualTo(CommentsFields.PARENT_ID, postId)
+        .whereEqualTo(CommentsFields.TAG, CommentTag.POST_COMMENT)
+        .get()
+        .await()
+        .documents
+        .mapNotNull { documentToComment(it) }
+  }
+
+  /**
+   * Retrieves all Comment items associated with a specific report.
+   *
+   * @param reportId The ID of the report for which to retrieve comments.
+   * @return A list of [Comment] items associated with the specified report.
+   */
+  override suspend fun getAllCommentsByReport(reportId: Id): List<Comment> {
+    return collection
+        .whereEqualTo(CommentsFields.PARENT_ID, reportId)
+        .whereEqualTo(CommentsFields.TAG, CommentTag.REPORT_COMMENT)
         .get()
         .await()
         .documents
@@ -71,9 +88,9 @@ class CommentRepositoryFirestore(private val db: FirebaseFirestore) : CommentRep
   /**
    * Deletes all Comment items of a post from the repository.
    *
-   * @param postId The ID of the post whose comments are to be deleted.
+   * @param postId The ID of the parent whose comments are to be deleted.
    */
-  override suspend fun deleteAllCommentsOfPost(postId: Id) {
+  override suspend fun deleteAllCommentsOfPost(postId: String) {
     getAllCommentsByPost(postId).forEach {
       if (it.tag == CommentTag.POST_COMMENT) {
         deleteComment(it.commentId)
@@ -87,7 +104,7 @@ class CommentRepositoryFirestore(private val db: FirebaseFirestore) : CommentRep
    * @param reportId The ID of the report whose comments are to be deleted.
    */
   override suspend fun deleteAllCommentsOfReport(reportId: Id) {
-    getAllCommentsByPost(reportId).forEach {
+    getAllCommentsByReport(reportId).forEach {
       if (it.tag == CommentTag.REPORT_COMMENT) {
         deleteComment(it.commentId)
       }
@@ -148,12 +165,12 @@ class CommentRepositoryFirestore(private val db: FirebaseFirestore) : CommentRep
    * @param document The document to be converted into a comment.
    * @return The transformed [Comment] object.
    */
-  fun documentToComment(document: DocumentSnapshot): Comment? {
+  private fun documentToComment(document: DocumentSnapshot): Comment? {
     return try {
       val commentId = document.id
-      val postId =
-          document.getString(CommentsFields.POST_ID)
-              ?: throwMissingFieldException(CommentsFields.POST_ID)
+      val parentId =
+          document.getString(CommentsFields.PARENT_ID)
+              ?: throwMissingFieldException(CommentsFields.PARENT_ID)
       val authorId =
           document.getString(CommentsFields.AUTHOR_ID)
               ?: throwMissingFieldException(CommentsFields.AUTHOR_ID)
@@ -168,7 +185,7 @@ class CommentRepositoryFirestore(private val db: FirebaseFirestore) : CommentRep
 
       Comment(
           commentId = commentId,
-          postId = postId,
+          parentId = parentId,
           authorId = authorId,
           text = text,
           date = date,

--- a/app/src/main/java/com/android/wildex/ui/post/PostDetailsScreenViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/post/PostDetailsScreenViewModel.kt
@@ -7,6 +7,7 @@ import com.android.wildex.model.RepositoryProvider
 import com.android.wildex.model.animal.AnimalRepository
 import com.android.wildex.model.social.Comment
 import com.android.wildex.model.social.CommentRepository
+import com.android.wildex.model.social.CommentTag
 import com.android.wildex.model.social.Like
 import com.android.wildex.model.social.LikeRepository
 import com.android.wildex.model.social.PostsRepository
@@ -271,11 +272,11 @@ class PostDetailsScreenViewModel(
         commentRepository.addComment(
             Comment(
                 commentId = commentId,
-                postId = postId,
+                parentId = postId,
                 authorId = currentUserId,
                 text = text,
                 date = now,
-            ))
+                tag = CommentTag.POST_COMMENT))
 
         // 3) Update count in the post (optional to keep server in sync)
         try {

--- a/app/src/test/java/com/android/wildex/dataClasses/DataClassesTest.kt
+++ b/app/src/test/java/com/android/wildex/dataClasses/DataClassesTest.kt
@@ -8,6 +8,7 @@ import com.android.wildex.model.relationship.Relationship
 import com.android.wildex.model.relationship.StatusEnum
 import com.android.wildex.model.report.Report
 import com.android.wildex.model.social.Comment
+import com.android.wildex.model.social.CommentTag
 import com.android.wildex.model.social.Like
 import com.android.wildex.model.social.Post
 import com.android.wildex.model.user.SimpleUser
@@ -111,14 +112,14 @@ class DataClassesTest {
     val comment =
         Comment(
             commentId = "comment1",
-            postId = "post1",
+            parentId = "post1",
             authorId = "user1",
             text = "This is a comment.",
             date = Timestamp.Companion.now(),
-        )
+            tag = CommentTag.POST_COMMENT)
 
     TestCase.assertEquals("comment1", comment.commentId)
-    TestCase.assertEquals("post1", comment.postId)
+    TestCase.assertEquals("post1", comment.parentId)
     TestCase.assertEquals("user1", comment.authorId)
     TestCase.assertEquals("This is a comment.", comment.text)
   }

--- a/app/src/test/java/com/android/wildex/ui/post/PostDetailsScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/post/PostDetailsScreenViewModelTest.kt
@@ -4,6 +4,7 @@ import com.android.wildex.model.animal.Animal
 import com.android.wildex.model.animal.AnimalRepository
 import com.android.wildex.model.social.Comment
 import com.android.wildex.model.social.CommentRepository
+import com.android.wildex.model.social.CommentTag
 import com.android.wildex.model.social.Like
 import com.android.wildex.model.social.LikeRepository
 import com.android.wildex.model.social.Post
@@ -72,32 +73,32 @@ class PostDetailsScreenViewModelTest {
       listOf(
           Comment(
               commentId = "comment1",
-              postId = "post1",
+              parentId = "post1",
               authorId = "commentAuthor1",
               text = "Great post!",
               date = Timestamp.now(),
-          ),
+              tag = CommentTag.POST_COMMENT),
           Comment(
               commentId = "comment2",
-              postId = "post1",
+              parentId = "post1",
               authorId = "commentAuthor1",
               text = "Thanks for sharing!",
               date = Timestamp.now(),
-          ),
+              tag = CommentTag.POST_COMMENT),
           Comment(
               commentId = "comment3",
-              postId = "post1",
+              parentId = "post1",
               authorId = "commentAuthor1",
               text = "It's beautiful!",
               date = Timestamp.now(),
-          ),
+              tag = CommentTag.POST_COMMENT),
           Comment(
               commentId = "comment4",
-              postId = "post1",
+              parentId = "post1",
               authorId = "commentAuthor1",
               text = "Would love to see it in person.",
               date = Timestamp.now(),
-          ),
+              tag = CommentTag.POST_COMMENT),
       )
 
   @Before

--- a/app/src/test/java/com/android/wildex/usecase/achievement/UpdateUserAchievementsUseCaseTest.kt
+++ b/app/src/test/java/com/android/wildex/usecase/achievement/UpdateUserAchievementsUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.android.wildex.model.achievement.InputKey
 import com.android.wildex.model.achievement.UserAchievementsRepository
 import com.android.wildex.model.social.Comment
 import com.android.wildex.model.social.CommentRepository
+import com.android.wildex.model.social.CommentTag
 import com.android.wildex.model.social.Like
 import com.android.wildex.model.social.LikeRepository
 import com.android.wildex.model.social.Post
@@ -67,17 +68,19 @@ class UpdateUserAchievementsUseCaseTest {
   private val c1 =
       Comment(
           commentId = "c1",
-          postId = "p1",
+          parentId = "p1",
           authorId = userId,
           text = "t1",
-          date = Timestamp.Companion.now())
+          date = Timestamp.Companion.now(),
+          tag = CommentTag.POST_COMMENT)
   private val c2 =
       Comment(
           commentId = "c2",
-          postId = "p2",
+          parentId = "p2",
           authorId = userId,
           text = "t2",
-          date = Timestamp.Companion.now())
+          date = Timestamp.Companion.now(),
+          tag = CommentTag.POST_COMMENT)
 
   @Before
   fun setUp() {


### PR DESCRIPTION
## Description
This PR updates the Comment data class by renaming the **postId** field to **parentId**. The change improves clarity: since a `Comment` can also be associated with a report, using the name postId is less appropriate and could lead to confusion.

This change required to adapt every file that used a `Comment` and the field **postId**

This PR also fixes a typo in `Comment.kt` and removes the default *POST_COMMENT* tag, two changes that were requested during a previous PR review but were accidentally forgotten.

Finally, this PR adds a **getAllCommentsByReport()** function, similar to **getAllCommentsByPost()**, to distinguish between post and report cases. Previously, the function retrieved all comments related to a given ID (whether it belonged to a post, a report, or even both) which sometimes caused report comments to appear in the comment section of a post with the same ID. This issue is now resolved by checking the comment’s tag.

## Related issues
Closes #253 

## How to test
Run every adapted test files to verify that this refactor hasn’t changed the app functionality.