### PR TITLE
feat: Implement UserFriends data class and its repository interface

### DIFF
--- a/app/src/main/java/com/android/wildex/model/user/User.kt
+++ b/app/src/main/java/com/android/wildex/model/user/User.kt
@@ -58,6 +58,19 @@ data class UserAnimals(
 )
 
 /**
+ * Represents a summary of a user's friends.
+ *
+ * @property userId The unique identifier of the user to whom these friends belong.
+ * @property friendsId A list of unique identifiers of the friends the user has.
+ * @property friendsCount The total number of friends the user has.
+ */
+data class UserFriends(
+    val userId: Id = "",
+    val friendsId: List<Id> = emptyList(),
+    val friendsCount: Int = 0,
+)
+
+/**
  * Represents the settings of a user.
  *
  * @property userId The unique identifier of the user to whom these settings belong.

--- a/app/src/main/java/com/android/wildex/model/user/UserFriendsRepository.kt
+++ b/app/src/main/java/com/android/wildex/model/user/UserFriendsRepository.kt
@@ -1,0 +1,25 @@
+package com.android.wildex.model.user
+
+import com.android.wildex.model.utils.Id
+
+/** Represents a repository that manages UserFriends items. */
+interface UserFriendsRepository {
+
+  /** Initializes UserFriends for a new User with empty list and zero count. */
+  suspend fun initializeUserFriends(userId: Id)
+
+  /** Retrieves UserFriends associated with a specific User. */
+  suspend fun getAllFriendsOfUser(userId: Id): List<Id>
+
+  /** Get UserFriends count of a specific User. */
+  suspend fun getFriendsCountOfUser(userId: Id): Int
+
+  /** Add a Friend to the UserFriends of a specific User. */
+  suspend fun addFriendToUserFriendsOfUser(friendId: Id, userId: Id)
+
+  /** Delete a Friend to the UserFriends of a specific User. */
+  suspend fun deleteFriendToUserFriendsOfUser(friendId: Id, userId: Id)
+
+  /** Delete the UserFriends linked to the given user */
+  suspend fun deleteUserFriendsOfUser(userId: Id)
+}


### PR DESCRIPTION
## Description
This PR defines the `UserFriends` data class, which is used to keep track of a user’s friends.

It also implements the `UserFriendsRepository` interface, providing functions that can:
- **Initialize** the `UserFriends` of a new user with an empty *friendIds* list and a *friendsCount* of 0.
- **Retrieve** the *friendIds* or *friendsCount* from a user’s `UserFriends`.
- **Add** a friend to a user’s `UserFriends`.
- **Remove** a friend from a user’s `UserFriends`.
- **Delete** a user’s `UserFriends`.

## Related issues
Closes #262 

## Trade-offs or known limitations 
This comment isn’t specific to `UserFriends`, but applies to all user-related data classes and repositories (`UserAnimals`, `UserAchievements` and `UserFriends`). 

I noticed that the function retrieving the list of animals (or achievements) in `UserAnimals` (or `UserAchievements`) literally returns a list of `Animal` (or `Achievement`) objects. An approach that might not be optimal since these lists could be large without always needing all their data. 

I think it would be better to only return the list of IDs of the `Animal` (or `Achievement`) objects, and then fetch the full details using the corresponding repository if needed. At least that's what I did for `UserFriends`, and I think we should do the same for the other classes and repositories (in a separate PR).