### PR TITLE
feat: implement getAnimalPicture function

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,7 @@ android {
   }
 
   val hfApiKey: String = localProperties.getProperty("HUGGINGFACE_API_KEY") ?: ""
+  val pxApiKey: String = localProperties.getProperty("PEXELS_API_KEY") ?: ""
   val mbApiKey: String = localProperties.getProperty("MAPBOX_ACCESS_TOKEN") ?: ""
 
   defaultConfig {
@@ -33,6 +34,7 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables { useSupportLibrary = true }
     buildConfigField("String", "HUGGINGFACE_API_KEY", "\"$hfApiKey\"")
+    buildConfigField("String", "PEXELS_API_KEY", "\"$pxApiKey\"")
     buildConfigField("String", "MAPBOX_ACCESS_TOKEN", "\"$mbApiKey\"")
   }
 
@@ -160,8 +162,8 @@ dependencies {
   implementation(libs.material)
   implementation(libs.androidx.lifecycle.runtime.ktx)
   implementation(platform(libs.compose.bom))
-    implementation(libs.androidx.material3)
-    testImplementation(libs.junit)
+  implementation(libs.androidx.material3)
+  testImplementation(libs.junit)
   globalTestImplementation(libs.androidx.junit)
   globalTestImplementation(libs.androidx.espresso.core)
   implementation(libs.kotlinx.serialization.json)

--- a/app/src/androidTest/java/com/android/wildex/utils/LocalRepositories.kt
+++ b/app/src/androidTest/java/com/android/wildex/utils/LocalRepositories.kt
@@ -456,9 +456,14 @@ object LocalRepositories {
     override suspend fun getAnimalDescription(
         animalName: String,
         coroutineContext: CoroutineContext
-    ): String? {
+    ): String {
       return "This is a default animal"
     }
+
+    override suspend fun getAnimalPicture(
+        animalName: String,
+        coroutineContext: CoroutineContext
+    ): URL = "imageUrl:$animalName"
   }
 
   val postsRepository: PostsRepository = PostsRepositoryImpl()

--- a/app/src/main/java/com/android/wildex/model/animaldetector/AnimalInfoRepository.kt
+++ b/app/src/main/java/com/android/wildex/model/animaldetector/AnimalInfoRepository.kt
@@ -2,6 +2,7 @@ package com.android.wildex.model.animaldetector
 
 import android.content.Context
 import android.net.Uri
+import com.android.wildex.model.utils.URL
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.Dispatchers
 
@@ -9,11 +10,16 @@ interface AnimalInfoRepository {
   suspend fun detectAnimal(
       context: Context,
       imageUri: Uri,
-      coroutineContext: CoroutineContext = Dispatchers.IO
+      coroutineContext: CoroutineContext = Dispatchers.IO,
   ): List<AnimalDetectResponse>
 
   suspend fun getAnimalDescription(
       animalName: String,
-      coroutineContext: CoroutineContext = Dispatchers.IO
-  ): String?
+      coroutineContext: CoroutineContext = Dispatchers.IO,
+  ): String
+
+  suspend fun getAnimalPicture(
+      animalName: String,
+      coroutineContext: CoroutineContext = Dispatchers.IO,
+  ): URL
 }

--- a/app/src/main/java/com/android/wildex/ui/camera/CameraScreenViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/camera/CameraScreenViewModel.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
 import android.util.Log
+import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.wildex.model.RepositoryProvider
@@ -140,11 +141,10 @@ class CameraScreenViewModel(
   /* registers the animal from the animal response in the repository if not already there */
   private suspend fun registerAnimal(animalId: Id) {
     val detection = uiState.value.animalDetectResponse ?: return
-    val animalDescription = animalInfoRepository.getAnimalDescription(detection.animalType) ?: ""
+    val animalDescription = animalInfoRepository.getAnimalDescription(detection.animalType)
 
-    // val animalPicture = animalRepository.getAnimalPicture(detection.animalType)
-    val animalPictureURL =
-        "" // storageRepository.uploadAnimalPicture(animalId, animalPicture) ?: ""
+    val animalPicture = animalInfoRepository.getAnimalPicture(detection.animalType).toUri()
+    val animalPictureURL = storageRepository.uploadAnimalPicture(animalId, animalPicture) ?: ""
     val animal =
         Animal(
             animalId,

--- a/app/src/test/java/com/android/wildex/model/animaldetector/AnimalPictureTest.kt
+++ b/app/src/test/java/com/android/wildex/model/animaldetector/AnimalPictureTest.kt
@@ -1,0 +1,155 @@
+package com.android.wildex.model.animaldetector
+
+import java.io.IOException
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class AnimalPictureTest : AnimalInfoRepositoryTest() {
+
+  override val urlPropName: String = "pexelsUrl"
+
+  @Test
+  fun `getAnimalPicture returns URL when response is successful`() = runBlocking {
+    val jsonResponse =
+        """
+        {
+          "photos": [
+            {
+              "src": {
+                "medium": "https://example.com/animal.jpg"
+              }
+            }
+          ]
+        }
+        """
+            .trimIndent()
+
+    mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(jsonResponse))
+
+    val result = repository.getAnimalPicture("lion")
+    assertEquals("https://example.com/animal.jpg", result)
+  }
+
+  @Test
+  fun `getAnimalPicture throws IOException on unsuccessful response`() = runBlocking {
+    mockWebServer.enqueue(MockResponse().setResponseCode(404).setBody("Not Found"))
+
+    val exception =
+        assertThrows(IOException::class.java) {
+          runBlocking { repository.getAnimalPicture("lion") }
+        }
+
+    assert(exception.message!!.contains("Unexpected code"))
+  }
+
+  @Test
+  fun `getAnimalPicture throws IOException when medium is missing`() = runBlocking {
+    val jsonResponse =
+        """
+        {
+          "photos": [
+            {
+              "src": {}
+            }
+          ]
+        }
+        """
+            .trimIndent()
+
+    mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(jsonResponse))
+
+    val exception =
+        assertThrows(IOException::class.java) {
+          runBlocking { repository.getAnimalPicture("lion") }
+        }
+
+    assert(exception.message!!.contains("No content found"))
+  }
+
+  @Test
+  fun `getAnimalPicture throws IOException when photos key is missing`() = runBlocking {
+    val jsonResponse = """{}"""
+    mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(jsonResponse))
+
+    val exception =
+        assertThrows(IOException::class.java) {
+          runBlocking { repository.getAnimalPicture("lion") }
+        }
+    assert(exception.message!!.contains("No content found"))
+  }
+
+  @Test
+  fun `getAnimalPicture throws IOException when first photo is null`() = runBlocking {
+    val jsonResponse = """{"photos": []}"""
+    mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(jsonResponse))
+
+    val exception =
+        assertThrows(IOException::class.java) {
+          runBlocking { repository.getAnimalPicture("lion") }
+        }
+    assert(exception.message!!.contains("No content found"))
+  }
+
+  @Test
+  fun `getAnimalPicture throws IOException when src key is missing`() = runBlocking {
+    val jsonResponse =
+        """
+        {
+          "photos": [
+            {}
+          ]
+        }
+    """
+            .trimIndent()
+    mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(jsonResponse))
+
+    val exception =
+        assertThrows(IOException::class.java) {
+          runBlocking { repository.getAnimalPicture("lion") }
+        }
+    assert(exception.message!!.contains("No content found"))
+  }
+
+  @Test
+  fun `getAnimalPicture throws IOException when medium key is missing`() = runBlocking {
+    val jsonResponse =
+        """
+        {
+          "photos": [
+            { "src": {} }
+          ]
+        }
+    """
+            .trimIndent()
+    mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(jsonResponse))
+
+    val exception =
+        assertThrows(IOException::class.java) {
+          runBlocking { repository.getAnimalPicture("lion") }
+        }
+    assert(exception.message!!.contains("No content found"))
+  }
+
+  @Test
+  fun `getAnimalPicture throws IOException when medium is not string`() = runBlocking {
+    val jsonResponse =
+        """
+        {
+          "photos": [
+            { "src": { "medium": 123 } }
+          ]
+        }
+    """
+            .trimIndent()
+    mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(jsonResponse))
+
+    val exception =
+        assertThrows(IOException::class.java) {
+          runBlocking { repository.getAnimalPicture("lion") }
+        }
+    assert(exception.message!!.contains("No content found"))
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces a new function to the `AnimalInfoRepository`: `getAnimalPicture`. This function's purpose comes when registering an animal i.e. when an animal gets detected for the first time, it basically fetches a representative photo URL of the animal online using the Pexels API.

* This PR is to be merged preferably after PR [274](https://github.com/wildex-swent/wildex-app/pull/274) for ease of merging.

## Related issues
Closes #273 

## Trade-offs and known limitations
This function depends on the Pexels API, and thus the Pexels search algorithm, quality of pictures, etc, so it is more than likely that for some animals the pictures will not be very representative.

## How to test
A temporary and easy solution to test the output is to go to the `CameraScreenViewModel`, in the `detectAnimalImage` function, and replace this line :
```kotlin
_uiState.value = _uiState.value.copy(animalDetectResponse = animalDetectResponse, isDetecting = false)
```
with this one :
```kotlin
_uiState.value = _uiState.value.copy(animalDetectResponse = animalDetectResponse, isDetecting = false, currentImageUri = animalInfoRepository.getAnimalPicture(animalDetectResponse.animalType).toUri())
```
Now simply go to the Camera screen, take or upload a picture of an animal of your choice, and the output of the function should be displayed in the post creation screen.
