### PR TITLE
refactor: add user typer to simple user

### DIFF
--- a/app/src/androidTest/java/com/android/wildex/model/user/UserRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/model/user/UserRepositoryFirestoreTest.kt
@@ -181,6 +181,7 @@ class UserRepositoryFirestoreTest : FirestoreTest(USERS_COLLECTION_PATH) {
             userId = user1.userId,
             username = user1.username,
             profilePictureURL = user1.profilePictureURL,
+            userType = user1.userType,
         )
     assertEquals(expectedSimple, simple)
   }

--- a/app/src/androidTest/java/com/android/wildex/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/map/MapScreenTest.kt
@@ -239,8 +239,8 @@ class MapScreenTest {
 
   @Test
   fun selectionBottomCard_report_assigned_row_and_open_click_and_all_tags_displayed() {
-    val assignee = SimpleUser(user1.userId, user1.username, user1.profilePictureURL)
-    val author = SimpleUser(user2.userId, user2.username, user2.profilePictureURL)
+    val assignee = SimpleUser(user1.userId, user1.username, user1.profilePictureURL, user1.userType)
+    val author = SimpleUser(user2.userId, user2.username, user2.profilePictureURL, user1.userType)
     setSelectionCard(
         selection = PinDetails.ReportDetails(report1, author = author, assignee = assignee),
         tab = MapTab.Reports,
@@ -375,7 +375,8 @@ class MapScreenTest {
     val details =
         PinDetails.PostDetails(
             post = post1.copy(location = Location(46.5, 6.6, "")),
-            author = SimpleUser(user1.userId, user1.username, user1.profilePictureURL),
+            author =
+                SimpleUser(user1.userId, user1.username, user1.profilePictureURL, user1.userType),
             likedByMe = true,
             animalName = "owl",
         )

--- a/app/src/androidTest/java/com/android/wildex/ui/report/ReportScreenTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/report/ReportScreenTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.android.wildex.model.report.Report
 import com.android.wildex.model.report.ReportRepository
-import com.android.wildex.model.user.SimpleUser
 import com.android.wildex.model.user.User
 import com.android.wildex.model.user.UserRepository
 import com.android.wildex.model.user.UserType
@@ -101,14 +100,6 @@ class ReportScreenTest {
     userRepository.addUser(user1)
     userRepository.addUser(user2)
     userRepository.addUser(user3)
-
-    val simpleUser1 = SimpleUser(userId = "user1", username = "Bob1", profilePictureURL = "urlBob1")
-
-    val simpleUser2 =
-        SimpleUser(userId = "user2", username = "Alice2", profilePictureURL = "urlAlice2")
-
-    val simpleUser3 =
-        SimpleUser(userId = "user3", username = "Charlie3", profilePictureURL = "urlCharlie3")
 
     reportScreenViewModel =
         ReportScreenViewModel(

--- a/app/src/androidTest/java/com/android/wildex/utils/LocalRepositories.kt
+++ b/app/src/androidTest/java/com/android/wildex/utils/LocalRepositories.kt
@@ -180,7 +180,7 @@ object LocalRepositories {
           userId = user.userId,
           username = user.username,
           profilePictureURL = user.profilePictureURL,
-      )
+          userType = user.userType)
     }
 
     override suspend fun addUser(user: User) {

--- a/app/src/main/java/com/android/wildex/model/user/SimpleUser.kt
+++ b/app/src/main/java/com/android/wildex/model/user/SimpleUser.kt
@@ -9,5 +9,11 @@ import com.android.wildex.model.utils.URL
  * @property userId The unique identifier for the user.
  * @property username The username of the user.
  * @property profilePictureURL The URL of the user's profile picture.
+ * @property userType The type of the user.
  */
-data class SimpleUser(val userId: Id, val username: String, val profilePictureURL: URL)
+data class SimpleUser(
+    val userId: Id,
+    val username: String,
+    val profilePictureURL: URL,
+    val userType: UserType,
+)

--- a/app/src/main/java/com/android/wildex/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/wildex/model/user/UserRepositoryFirestore.kt
@@ -114,7 +114,13 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore) : UserRepositor
       val id = document.id
       val username = document.getString("username") ?: return null
       val profilePictureURL = document.getString("profilePictureURL") ?: ""
-      SimpleUser(userId = id, username = username, profilePictureURL = profilePictureURL)
+      val userType =
+          document.getString("userType")?.let { UserType.valueOf(it) } ?: UserType.REGULAR
+      SimpleUser(
+          userId = id,
+          username = username,
+          profilePictureURL = profilePictureURL,
+          userType = userType)
     } catch (e: Exception) {
       Log.e(TAG, "documentToSimpleUser: error converting document ${document.id}", e)
       null

--- a/app/src/main/java/com/android/wildex/ui/collection/CollectionScreenViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/collection/CollectionScreenViewModel.kt
@@ -7,6 +7,7 @@ import com.android.wildex.model.animal.AnimalRepository
 import com.android.wildex.model.user.SimpleUser
 import com.android.wildex.model.user.UserAnimalsRepository
 import com.android.wildex.model.user.UserRepository
+import com.android.wildex.model.user.UserType
 import com.android.wildex.model.utils.Id
 import com.android.wildex.model.utils.URL
 import com.google.firebase.auth.ktx.auth
@@ -18,7 +19,11 @@ import kotlinx.coroutines.launch
 
 /** Default placeholder user used when no valid user is loaded. */
 private val defaultUser: SimpleUser =
-    SimpleUser(userId = "defaultUserId", username = "defaultUsername", profilePictureURL = "")
+    SimpleUser(
+        userId = "defaultUserId",
+        username = "defaultUsername",
+        profilePictureURL = "",
+        userType = UserType.REGULAR)
 
 data class CollectionUIState(
     val user: SimpleUser = defaultUser,

--- a/app/src/main/java/com/android/wildex/ui/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/home/HomeScreenViewModel.kt
@@ -16,6 +16,7 @@ import com.android.wildex.model.social.Post
 import com.android.wildex.model.social.PostsRepository
 import com.android.wildex.model.user.SimpleUser
 import com.android.wildex.model.user.UserRepository
+import com.android.wildex.model.user.UserType
 import com.android.wildex.model.utils.Id
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
@@ -43,7 +44,11 @@ data class HomeUIState(
 
 /** Default placeholder user used when no valid user is loaded. */
 private val defaultUser: SimpleUser =
-    SimpleUser(userId = "defaultUserId", username = "defaultUsername", profilePictureURL = "")
+    SimpleUser(
+        userId = "defaultUserId",
+        username = "defaultUsername",
+        profilePictureURL = "",
+        userType = UserType.REGULAR)
 /**
  * Combines post data with associated metadata for display.
  *

--- a/app/src/main/java/com/android/wildex/ui/report/ReportScreen.kt
+++ b/app/src/main/java/com/android/wildex/ui/report/ReportScreen.kt
@@ -112,7 +112,7 @@ fun ReportScreen(
       topBar = {
         ReportScreenTopBar(
             userId = uiState.currentUser.userId,
-            userType = uiState.currentUserType,
+            userType = uiState.currentUser.userType,
             userProfilePictureURL = uiState.currentUser.profilePictureURL,
             onProfileClick = onProfileClick,
             onNotificationClick = onNotificationClick,
@@ -136,7 +136,7 @@ fun ReportScreen(
                 reports = uiState.reports,
                 userId = uiState.currentUser.userId,
                 username = uiState.currentUser.username,
-                userType = uiState.currentUserType,
+                userType = uiState.currentUser.userType,
                 onProfileClick = onProfileClick,
                 onReportClick = onReportClick,
                 cancelReport = reportScreenViewModel::cancelReport,

--- a/app/src/test/java/com/android/wildex/dataClasses/DataClassesTest.kt
+++ b/app/src/test/java/com/android/wildex/dataClasses/DataClassesTest.kt
@@ -164,11 +164,13 @@ class DataClassesTest {
             userId = "user1",
             username = "TestUser",
             profilePictureURL = "https://example.com/user_pic",
+            userType = UserType.REGULAR,
         )
 
     TestCase.assertEquals("user1", simpleUser.userId)
     TestCase.assertEquals("TestUser", simpleUser.username)
     TestCase.assertEquals("https://example.com/user_pic", simpleUser.profilePictureURL)
+    TestCase.assertEquals(UserType.REGULAR, simpleUser.userType)
   }
 
   @Test

--- a/app/src/test/java/com/android/wildex/ui/collection/CollectionScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/collection/CollectionScreenViewModelTest.kt
@@ -64,21 +64,24 @@ class CollectionScreenViewModelTest {
           userId = "currentUserId",
           username = "currentUsername",
           profilePictureURL =
-              "https://www.shareicon.net/data/512x512/2016/05/24/770137_man_512x512.png")
+              "https://www.shareicon.net/data/512x512/2016/05/24/770137_man_512x512.png",
+          userType = UserType.REGULAR,
+      )
 
   private val su2 =
       SimpleUser(
           userId = "otherUserId",
           username = "otherUsername",
           profilePictureURL =
-              "https://www.shareicon.net/data/512x512/2016/05/24/770137_man_512x512.png")
+              "https://www.shareicon.net/data/512x512/2016/05/24/770137_man_512x512.png",
+          userType = UserType.REGULAR)
 
   private val defaultUser: SimpleUser =
       SimpleUser(
           userId = "defaultUserId",
           username = "defaultUsername",
           profilePictureURL = "",
-      )
+          userType = UserType.REGULAR)
 
   private val a1 =
       Animal(

--- a/app/src/test/java/com/android/wildex/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/home/HomeScreenViewModelTest.kt
@@ -9,6 +9,7 @@ import com.android.wildex.model.social.Post
 import com.android.wildex.model.social.PostsRepository
 import com.android.wildex.model.user.SimpleUser
 import com.android.wildex.model.user.UserRepository
+import com.android.wildex.model.user.UserType
 import com.android.wildex.model.utils.Location
 import com.android.wildex.utils.MainDispatcherRule
 import com.google.firebase.Timestamp
@@ -35,7 +36,11 @@ class HomeScreenViewModelTest {
   private lateinit var viewModel: HomeScreenViewModel
 
   private val defaultUser: SimpleUser =
-      SimpleUser(userId = "defaultUserId", username = "defaultUsername", profilePictureURL = "")
+      SimpleUser(
+          userId = "defaultUserId",
+          username = "defaultUsername",
+          profilePictureURL = "",
+          userType = UserType.REGULAR)
 
   private val p1 =
       Post(
@@ -63,10 +68,15 @@ class HomeScreenViewModelTest {
           commentsCount = 1,
       )
 
-  private val u1 = SimpleUser(userId = "uid-1", username = "user_one", profilePictureURL = "u")
+  private val u1 =
+      SimpleUser(
+          userId = "uid-1",
+          username = "user_one",
+          profilePictureURL = "u",
+          userType = UserType.REGULAR)
 
-  private val author1 = SimpleUser("author1", "author_one", "url1")
-  private val author2 = SimpleUser("author2", "author_two", "url2")
+  private val author1 = SimpleUser("author1", "author_one", "url1", userType = UserType.REGULAR)
+  private val author2 = SimpleUser("author2", "author_two", "url2", userType = UserType.REGULAR)
 
   private val like1 = Like(likeId = "like1", postId = "p1", userId = "author-2")
 

--- a/app/src/test/java/com/android/wildex/ui/map/MapScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/map/MapScreenViewModelTest.kt
@@ -97,7 +97,8 @@ class MapScreenViewModelTest {
         coEvery { postsRepository.getAllPosts() } returns listOf(post1, post2)
         coEvery { postsRepository.getAllPostsByGivenAuthor(any()) } returns listOf(post2)
         coEvery { reportRepository.getAllReports() } returns emptyList()
-        coEvery { userRepository.getSimpleUser(any()) } returns SimpleUser("a", "b", "c")
+        coEvery { userRepository.getSimpleUser(any()) } returns
+            SimpleUser("a", "b", "c", userType = UserType.REGULAR)
 
         viewModel.loadUIState(loggedInUserId)
         advanceUntilIdle()
@@ -119,7 +120,8 @@ class MapScreenViewModelTest {
         coEvery { userRepository.getUser(loggedInUserId) } returns regularUser
         coEvery { postsRepository.getAllPosts() } returns listOf(post1, post2)
         coEvery { postsRepository.getAllPostsByGivenAuthor(any()) } returns listOf(post2)
-        coEvery { userRepository.getSimpleUser(any()) } returns SimpleUser("a", "b", "c")
+        coEvery { userRepository.getSimpleUser(any()) } returns
+            SimpleUser("a", "b", "c", userType = UserType.REGULAR)
 
         viewModel.loadUIState(loggedInUserId)
         advanceUntilIdle()
@@ -138,7 +140,8 @@ class MapScreenViewModelTest {
   fun pinSelection_loadsCorrectDetails_forPostAndReport() =
       mainDispatcherRule.runTest {
         coEvery { userRepository.getUser(loggedInUserId) } returns proUser
-        coEvery { userRepository.getSimpleUser(any()) } returns SimpleUser("x", "y", "url")
+        coEvery { userRepository.getSimpleUser(any()) } returns
+            SimpleUser("x", "y", "url", userType = UserType.REGULAR)
         coEvery { postsRepository.getAllPosts() } returns listOf(post1)
         coEvery { postsRepository.getPost("p1") } returns post1
         coEvery { likeRepository.getLikeForPost(any()) } returns null
@@ -164,7 +167,8 @@ class MapScreenViewModelTest {
         coEvery { userRepository.getUser(loggedInUserId) } returns regularUser
         coEvery { postsRepository.getAllPosts() } returns listOf(post1)
         coEvery { postsRepository.getPost("p1") } returns post1
-        coEvery { userRepository.getSimpleUser(any()) } returns SimpleUser("x", "y", "url")
+        coEvery { userRepository.getSimpleUser(any()) } returns
+            SimpleUser("x", "y", "url", userType = UserType.REGULAR)
         coEvery { likeRepository.getLikeForPost("p1") } returns null
         coEvery { likeRepository.getNewLikeId() } returns "like-1"
 
@@ -217,7 +221,8 @@ class MapScreenViewModelTest {
         val r1Dup = r1.copy()
         val r2Assigned = report2
         coEvery { userRepository.getUser(loggedInUserId) } returns regularUser
-        coEvery { userRepository.getSimpleUser(any()) } returns SimpleUser("u", "n", "pic")
+        coEvery { userRepository.getSimpleUser(any()) } returns
+            SimpleUser("u", "n", "pic", userType = UserType.REGULAR)
         coEvery { postsRepository.getAllPostsByGivenAuthor(otherUserId) } returns emptyList()
         coEvery { reportRepository.getAllReportsByAuthor(otherUserId) } returns listOf(r1, r1Dup)
         coEvery { reportRepository.getAllReportsByAssignee(otherUserId) } returns listOf(r2Assigned)
@@ -241,7 +246,8 @@ class MapScreenViewModelTest {
   fun errorBranches_cover_blankUid_AnimalFallback_pinFail_and_toggleFailureRollback() =
       mainDispatcherRule.runTest {
         coEvery { userRepository.getUser(loggedInUserId) } returns regularUser
-        coEvery { userRepository.getSimpleUser(any()) } returns SimpleUser("s", "u", "p")
+        coEvery { userRepository.getSimpleUser(any()) } returns
+            SimpleUser("s", "u", "p", userType = UserType.REGULAR)
         coEvery { postsRepository.getAllPosts() } returns listOf(post1)
         coEvery { reportRepository.getAllReports() } returns emptyList()
 
@@ -295,7 +301,8 @@ class MapScreenViewModelTest {
         coEvery { userRepository.getUser(loggedInUserId) } returns regularUser
         coEvery { postsRepository.getAllPosts() } returns listOf(post1, post2)
         coEvery { postsRepository.getPost("p1") } returns post1
-        coEvery { userRepository.getSimpleUser(any()) } returns SimpleUser("x", "y", "url")
+        coEvery { userRepository.getSimpleUser(any()) } returns
+            SimpleUser("x", "y", "url", userType = UserType.REGULAR)
         coEvery { likeRepository.getLikeForPost("p1") } returns Like("lk1", "p1", loggedInUserId)
         coEvery { likeRepository.deleteLike("lk1") } returns Unit
 

--- a/app/src/test/java/com/android/wildex/ui/post/PostDetailsScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/post/PostDetailsScreenViewModelTest.kt
@@ -11,6 +11,7 @@ import com.android.wildex.model.social.Post
 import com.android.wildex.model.social.PostsRepository
 import com.android.wildex.model.user.SimpleUser
 import com.android.wildex.model.user.UserRepository
+import com.android.wildex.model.user.UserType
 import com.android.wildex.model.utils.Location
 import com.android.wildex.utils.MainDispatcherRule
 import com.google.firebase.Timestamp
@@ -59,7 +60,7 @@ class PostDetailsScreenViewModelTest {
           username = "tiger_lover",
           profilePictureURL =
               "https://vectorportal.com/storage/d5YN3OWWLMAJMqMZZJsITZT6bUniD0mbd2HGVNkB.jpg",
-      )
+          userType = UserType.REGULAR)
 
   private val testCommentsAuthor =
       SimpleUser(
@@ -67,7 +68,7 @@ class PostDetailsScreenViewModelTest {
           username = "joe34",
           profilePictureURL =
               "https://vectorportal.com/storage/KIygRdXXMVXBs09f42hJ4VWOYVZIX9WdhOJP7Rf4.jpg",
-      )
+          userType = UserType.REGULAR)
 
   private val testComments =
       listOf(
@@ -121,7 +122,7 @@ class PostDetailsScreenViewModelTest {
     coEvery { userRepository.getSimpleUser("poster1") } returns testPostSimpleAuthor
     coEvery { userRepository.getSimpleUser("commentAuthor1") } returns testCommentsAuthor
     coEvery { userRepository.getSimpleUser("currentUserId-1") } returns
-        SimpleUser("currentUserId-1", "me", "url")
+        SimpleUser("currentUserId-1", "me", "url", userType = UserType.REGULAR)
     coEvery { commentRepository.getAllCommentsByPost("post1") } returns testComments
     coEvery { postsRepository.editPost(any(), any()) } just Runs
     coEvery { likeRepository.getNewLikeId() } returns "like1"

--- a/app/src/test/java/com/android/wildex/ui/report/ReportScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/report/ReportScreenViewModelTest.kt
@@ -74,14 +74,14 @@ class ReportScreenViewModelTest {
           userId = "user1",
           username = "user1name",
           profilePictureURL = "user1URL",
-      )
+          userType = UserType.REGULAR)
 
   private val simpleUser2 =
       SimpleUser(
           userId = "user2",
           username = "user2name",
           profilePictureURL = "user2URL",
-      )
+          userType = UserType.REGULAR)
 
   private val user2 =
       User(
@@ -101,7 +101,7 @@ class ReportScreenViewModelTest {
           userId = "user3",
           username = "user3name",
           profilePictureURL = "user3URL",
-      )
+          userType = UserType.PROFESSIONAL)
 
   private val user3 =
       User(
@@ -121,7 +121,7 @@ class ReportScreenViewModelTest {
           userId = "defaultUserId",
           username = "defaultUsername",
           profilePictureURL = "",
-      )
+          userType = UserType.REGULAR)
 
   @Before
   fun setUp() {
@@ -150,7 +150,6 @@ class ReportScreenViewModelTest {
     val initialState = viewModel.uiState.value
     assertTrue(initialState.reports.isEmpty())
     assertEquals(defaultUser, initialState.currentUser)
-    assertEquals(UserType.REGULAR, initialState.currentUserType)
     assertNull(initialState.errorMsg)
     assertFalse(initialState.isLoading)
     assertFalse(initialState.isRefreshing)
@@ -198,7 +197,6 @@ class ReportScreenViewModelTest {
       assertEquals(expectedReportAssignees, actualReportAssignees)
 
       assertEquals(simpleUser2, state.currentUser)
-      assertEquals(UserType.REGULAR, state.currentUserType)
       assertNull(state.errorMsg)
       assertFalse(state.isLoading)
       assertFalse(state.isRefreshing)
@@ -218,7 +216,6 @@ class ReportScreenViewModelTest {
       // user 3 is a professional user so he sees all reports
       assertEquals(expectedReportIds, actualReportIds)
       assertEquals(simpleUser3, state.currentUser)
-      assertEquals(UserType.PROFESSIONAL, state.currentUserType)
       assertNull(state.errorMsg)
       assertFalse(state.isLoading)
       assertFalse(state.isRefreshing)
@@ -283,7 +280,7 @@ class ReportScreenViewModelTest {
   @Test
   fun loadUIState_sets_error_when_User_fails() {
     mainDispatcherRule.runTest {
-      coEvery { userRepository.getUser("user3") } throws Exception("Error getting user")
+      coEvery { userRepository.getSimpleUser("user3") } throws Exception("Error getting user")
       coEvery { reportRepository.getAllReportsByAuthor("user3") } returns emptyList()
 
       viewModel.loadUIState()


### PR DESCRIPTION
## Description
This PR refactors the `SimpleUser` data class to include a `userType` field. This change is needed to facilitate the #265 issue: in screens where we use `SimpleUser` instances to display clickable profile pictures, the user type will determine whether the professional badge will be displayed. It will also allow some screens to have all information needed through just `getSimpleUser()`, instead of fetching a lot of extra unnecessary information with `getUser()` (as shown in the refactoring of `ReportScreenViewModel`)

The `SimpleUser` data class is of course mofidifed, and several view models and tests are updated in order to reflect this change. It's mostly correcting instances of `SimpleUser`

## Related issues
Closes #280 

## Trade-offs or known limitations 
Some other screens may also benefit from a logic refactoring where this new refactoring is utilized. We should go through and check that during the next meeting.