### PR TITLE
feature: report details view model

### DIFF
--- a/app/src/main/java/com/android/wildex/ui/report/ReportDetailScreenViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/report/ReportDetailScreenViewModel.kt
@@ -160,7 +160,7 @@ class ReportDetailsScreenViewModel(
 
       // ------ Non Fatal errors ------
 
-      // Sooo since these don't break the code, I thought maybe we could collect all errors
+      // Sooo I don't think these should break the code, I thought maybe we could collect all errors
       // and show them at once at the end
       var localErrorMsg: String? = null
       fun appendError(msg: String) {
@@ -222,7 +222,7 @@ class ReportDetailsScreenViewModel(
     }
   }
 
-  /** Cancels a report created by a regular user. */
+  /** Cancels a report */
   fun cancelReport() {
     val reportId = _uiState.value.reportId
     viewModelScope.launch {
@@ -316,7 +316,7 @@ class ReportDetailsScreenViewModel(
     }
   }
 
-  /** Optimistic comment add with rollback on failure, similar to PostDetails. */
+  /** Optimistic comment add with rollback on failure */
   fun addComment(text: String = "") {
     if (text.isBlank()) return
     viewModelScope.launch {


### PR DESCRIPTION
## Description
This PR adds the full ViewModel logic for the Report Details screen along with its tests.  

## What’s Included
• Loads a report and maps all associated data to a clean `ReportDetailsUIState`  
• Handles non-fatal errors (author/assignee/comments) without breaking the screen  
• Supports fatal error handling with `isError`  
• Implements self-assign / unassign / cancel / resolve flows  
• Emits `ShowCompletion` events on cancellations or resolutions  
• Optimistic comment posting with rollback on failure  
• Consistent date formatting and UI-ready comment models  

## Related Issues
Related to  #217 .

## How to Test
Run `ReportDetailsScreenViewModelTest`  

