### PR TITLE
Implement Friend Screen ViewModel

### DIFF
--- a/app/src/test/java/com/android/wildex/ui/social/FriendScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/social/FriendScreenViewModelTest.kt
@@ -179,8 +179,7 @@ class FriendScreenViewModelTest {
       deferred.complete(userFriends1.friendsId)
       advanceUntilIdle()
       val state = viewModel.uiState.value
-      val expectedFriendStates =
-          listOf(FriendState(su2, isFriend = true, isPending = false, isCurrentUser = false))
+      val expectedFriendStates = listOf(FriendState(friend = su2, status = FriendStatus.FRIEND))
       Assert.assertEquals(expectedFriendStates, state.friends)
       Assert.assertEquals(suggestions, state.suggestions)
       Assert.assertEquals(listOf(request2), state.receivedRequests)
@@ -226,8 +225,8 @@ class FriendScreenViewModelTest {
       val state = viewModel.uiState.value
       val expectedFriendStates =
           listOf(
-              FriendState(su1, isFriend = false, isPending = false, isCurrentUser = true),
-              FriendState(su3, isFriend = false, isPending = true, isCurrentUser = false))
+              FriendState(su1, FriendStatus.IS_CURRENT_USER),
+              FriendState(su3, FriendStatus.PENDING_SENT))
       Assert.assertEquals(expectedFriendStates, state.friends)
       Assert.assertEquals(emptyList<RecommendationResult>(), state.suggestions)
       Assert.assertEquals(emptyList<FriendRequest>(), state.receivedRequests)
@@ -273,8 +272,7 @@ class FriendScreenViewModelTest {
       deferred.complete(userFriends1.friendsId)
       advanceUntilIdle()
       val state = viewModel.uiState.value
-      val expectedFriendStates =
-          listOf(FriendState(su2, isFriend = true, isPending = false, isCurrentUser = false))
+      val expectedFriendStates = listOf(FriendState(su2, FriendStatus.FRIEND))
       Assert.assertEquals(expectedFriendStates, state.friends)
       Assert.assertEquals(suggestions, state.suggestions)
       Assert.assertEquals(listOf(request2), state.receivedRequests)
@@ -300,8 +298,7 @@ class FriendScreenViewModelTest {
       advanceUntilIdle()
       val state = viewModel.uiState.value
       val expectedSentRequests = listOf(request1) + listOf(FriendRequest(u1.userId, u4.userId))
-      val expectedFriendStates =
-          listOf(FriendState(su2, isFriend = true, isPending = false, isCurrentUser = false))
+      val expectedFriendStates = listOf(FriendState(su2, FriendStatus.FRIEND))
       val expectedSuggestions =
           listOf(
               RecommendationResult(su3, "is the chosen one"),
@@ -353,16 +350,16 @@ class FriendScreenViewModelTest {
       val oldState = viewModel.uiState.value
       val expectedFriendOldStates =
           listOf(
-              FriendState(su1, isFriend = false, isPending = false, isCurrentUser = true),
-              FriendState(su3, isFriend = false, isPending = false, isCurrentUser = false))
+              FriendState(su1, FriendStatus.IS_CURRENT_USER),
+              FriendState(su3, FriendStatus.NOT_FRIEND))
       Assert.assertEquals(expectedFriendOldStates, oldState.friends)
       viewModel.sendRequestToUser(u3.userId)
       advanceUntilIdle()
       val newState = viewModel.uiState.value
       val expectedFriendStates =
           listOf(
-              FriendState(su1, isFriend = false, isPending = false, isCurrentUser = true),
-              FriendState(su3, isFriend = false, isPending = true, isCurrentUser = false))
+              FriendState(su1, FriendStatus.IS_CURRENT_USER),
+              FriendState(su3, FriendStatus.PENDING_SENT))
       Assert.assertEquals(expectedFriendStates, newState.friends)
       Assert.assertEquals(emptyList<RecommendationResult>(), newState.suggestions)
       Assert.assertEquals(emptyList<FriendRequest>(), newState.receivedRequests)
@@ -387,8 +384,7 @@ class FriendScreenViewModelTest {
       viewModel.unfollowUser(u2.userId)
       advanceUntilIdle()
       val state = viewModel.uiState.value
-      val expectedFriendStates =
-          listOf(FriendState(su2, isFriend = false, isPending = false, isCurrentUser = false))
+      val expectedFriendStates = listOf(FriendState(su2, FriendStatus.NOT_FRIEND))
       Assert.assertEquals(expectedFriendStates, state.friends)
       Assert.assertEquals(suggestions, state.suggestions)
       Assert.assertEquals(listOf(request2), state.receivedRequests)
@@ -441,9 +437,7 @@ class FriendScreenViewModelTest {
       advanceUntilIdle()
       val state = viewModel.uiState.value
       val expectedReceivedRequests = emptyList<FriendRequest>()
-      val expectedFriendStates =
-          friendStates +
-              listOf(FriendState(su4, isFriend = true, isPending = false, isCurrentUser = false))
+      val expectedFriendStates = friendStates + listOf(FriendState(su4, FriendStatus.FRIEND))
       Assert.assertEquals(expectedFriendStates, state.friends)
       Assert.assertEquals(suggestions, state.suggestions)
       Assert.assertEquals(expectedReceivedRequests, state.receivedRequests)
@@ -493,8 +487,7 @@ class FriendScreenViewModelTest {
       advanceUntilIdle()
       val state = viewModel.uiState.value
       val expectedReceivedRequests = emptyList<FriendRequest>()
-      val expectedFriendStates =
-          listOf(FriendState(su2, isFriend = true, isPending = false, isCurrentUser = false))
+      val expectedFriendStates = listOf(FriendState(su2, FriendStatus.FRIEND))
       Assert.assertEquals(expectedFriendStates, state.friends)
       Assert.assertEquals(suggestions, state.suggestions)
       Assert.assertEquals(expectedReceivedRequests, state.receivedRequests)
@@ -545,8 +538,7 @@ class FriendScreenViewModelTest {
       advanceUntilIdle()
       val state = viewModel.uiState.value
       val expectedSentRequest = emptyList<FriendRequest>()
-      val expectedFriendStates =
-          listOf(FriendState(su2, isFriend = true, isPending = false, isCurrentUser = false))
+      val expectedFriendStates = listOf(FriendState(su2, FriendStatus.FRIEND))
       Assert.assertEquals(expectedFriendStates, state.friends)
       Assert.assertEquals(suggestions, state.suggestions)
       Assert.assertEquals(listOf(request2), state.receivedRequests)
@@ -574,8 +566,8 @@ class FriendScreenViewModelTest {
       val expectedSentRequests = emptyList<FriendRequest>()
       val expectedFriendStates =
           listOf(
-              FriendState(su1, isFriend = false, isPending = false, isCurrentUser = true),
-              FriendState(su3, isFriend = false, isPending = false, isCurrentUser = false))
+              FriendState(su1, FriendStatus.IS_CURRENT_USER),
+              FriendState(su3, FriendStatus.NOT_FRIEND))
       Assert.assertEquals(expectedFriendStates, state.friends)
       Assert.assertEquals(emptyList<RecommendationResult>(), state.suggestions)
       Assert.assertEquals(emptyList<FriendRequest>(), state.receivedRequests)


### PR DESCRIPTION
## Description
This PR implements the ViewModel of the Friend Screen. The operations allowed by this ViewModel are the following:
- Send a friend request
- Cancel a sent friend request
- Accept a received friend request
- Decline a received friend request
- Unfollow a user

All of these operations are implemented using a rollback mechanism so that latency for screen updates is avoided but state integrity is still maintained by the rollback in case of an exception in the repositories (inspiration was taken from @Rania5724 's Report Details Screen ViewModel).

The ViewModel includes support for a loading screen and also refreshing.

About suggestions from the friend suggestion algorithm, the ViewModel maintains at all times a list of suggested users. Whenever a user from the suggestions is followed, a new suggestion replaces the old one (if there are still users to suggest) to always have some suggestions for the current user. To limit computations, suggestions are recomputed only when the maintained list becomes too small, or when the screen is refreshed.

## Related issues
Closes #214 

## How to test
Run `FriendScreenViewModelTest.kt`