### PR TITLE
feat: implement notification repository for firestore

### DIFF
--- a/app/src/androidTest/java/com/android/wildex/model/notification/NotificationRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/model/notification/NotificationRepositoryFirestoreTest.kt
@@ -1,0 +1,289 @@
+package com.android.wildex.model.notification
+
+import com.android.wildex.utils.FirebaseEmulator
+import com.android.wildex.utils.FirestoreTest
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.DocumentSnapshot
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+const val NOTIFICATION_COLLECTION_PATH = "notifications"
+
+class NotificationRepositoryFirestoreTest : FirestoreTest(NOTIFICATION_COLLECTION_PATH) {
+
+  private val repository = NotificationRepositoryFirestore(FirebaseEmulator.firestore)
+  val notification1 =
+      Notification(
+          notificationId = "notification1",
+          targetId = "target1",
+          authorId = "author1",
+          isRead = false,
+          title = "title1",
+          body = "body1",
+          route = "route1",
+          date = Timestamp(1, 0),
+      )
+
+  val notification2 =
+      Notification(
+          notificationId = "notification2",
+          targetId = "target2",
+          authorId = "author2",
+          isRead = false,
+          title = "title2",
+          body = "body2",
+          route = "route2",
+          date = Timestamp(2, 0),
+      )
+
+  val notification3 =
+      Notification(
+          notificationId = "notification3",
+          targetId = "target1",
+          authorId = "author3",
+          isRead = true,
+          title = "title3",
+          body = "body3",
+          route = "route3",
+          date = Timestamp(3, 0),
+      )
+
+  @Before
+  fun setup() {
+    super.setUp()
+    // Populate the repository with some test data
+    runBlocking {
+      FirebaseEmulator.firestore
+          .collection(NOTIFICATION_COLLECTION_PATH)
+          .document(notification1.notificationId)
+          .set(notification1)
+          .await()
+      FirebaseEmulator.firestore
+          .collection(NOTIFICATION_COLLECTION_PATH)
+          .document(notification2.notificationId)
+          .set(notification2)
+          .await()
+      FirebaseEmulator.firestore
+          .collection(NOTIFICATION_COLLECTION_PATH)
+          .document(notification3.notificationId)
+          .set(notification3)
+          .await()
+    }
+  }
+
+  @Test
+  fun testGetAllNotificationsForUser() = runTest {
+    val notifications = repository.getAllNotificationsForUser("target1")
+    assertEquals(listOf(notification1, notification3), notifications)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testGetAllNotificationsForUser_MissingAuthorId() = runTest {
+    FirebaseEmulator.firestore
+        .collection(NOTIFICATION_COLLECTION_PATH)
+        .document("notification4")
+        .set(
+            mapOf(
+                "targetId" to "target4",
+                "isRead" to true,
+                "title" to "title4",
+                "body" to "body4",
+                "route" to "route4",
+                "date" to Timestamp(4, 0),
+            ))
+        .await()
+    repository.getAllNotificationsForUser("target4")
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testGetAllNotificationsForUser_MissingTitle() = runTest {
+    FirebaseEmulator.firestore
+        .collection(NOTIFICATION_COLLECTION_PATH)
+        .document("notification4")
+        .set(
+            mapOf(
+                "targetId" to "target4",
+                "authorId" to "author4",
+                "isRead" to true,
+                "body" to "body4",
+                "route" to "route4",
+                "date" to Timestamp(4, 0),
+            ))
+        .await()
+    repository.getAllNotificationsForUser("target4")
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testGetAllNotificationsForUser_MissingBody() = runTest {
+    FirebaseEmulator.firestore
+        .collection(NOTIFICATION_COLLECTION_PATH)
+        .document("notification4")
+        .set(
+            mapOf(
+                "targetId" to "target4",
+                "authorId" to "author4",
+                "isRead" to true,
+                "title" to "title4",
+                "route" to "route4",
+                "date" to Timestamp(4, 0),
+            ))
+        .await()
+    repository.getAllNotificationsForUser("target4")
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testGetAllNotificationsForUser_MissingRoute() = runTest {
+    FirebaseEmulator.firestore
+        .collection(NOTIFICATION_COLLECTION_PATH)
+        .document("notification4")
+        .set(
+            mapOf(
+                "targetId" to "target4",
+                "authorId" to "author4",
+                "isRead" to true,
+                "title" to "title4",
+                "body" to "body4",
+                "date" to Timestamp(4, 0),
+            ))
+        .await()
+    repository.getAllNotificationsForUser("target4")
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testGetAllNotificationsForUser_MissingIsRead() = runTest {
+    FirebaseEmulator.firestore
+        .collection(NOTIFICATION_COLLECTION_PATH)
+        .document("notification4")
+        .set(
+            mapOf(
+                "targetId" to "target4",
+                "authorId" to "author4",
+                "title" to "title4",
+                "body" to "body4",
+                "route" to "route4",
+                "date" to Timestamp(4, 0),
+            ))
+        .await()
+    repository.getAllNotificationsForUser("target4")
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testGetAllNotificationsForUser_MissingDate() = runTest {
+    FirebaseEmulator.firestore
+        .collection(NOTIFICATION_COLLECTION_PATH)
+        .document("notification4")
+        .set(
+            mapOf(
+                "targetId" to "target4",
+                "authorId" to "author4",
+                "isRead" to true,
+                "title" to "title4",
+                "body" to "body4",
+                "route" to "route4",
+            ))
+        .await()
+    repository.getAllNotificationsForUser("target4")
+  }
+
+  @Test
+  fun testMarkNotificationAsRead() = runTest {
+    repository.markNotificationAsRead("notification1")
+    val updatedNotification =
+        FirebaseEmulator.firestore
+            .collection(NOTIFICATION_COLLECTION_PATH)
+            .document("notification1")
+            .get()
+            .await()
+            .toNotification()
+
+    assert(updatedNotification.isRead)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testMarkNotificationAsRead_NonExistentNotification() = runTest {
+    repository.markNotificationAsRead("nonExistentNotification")
+  }
+
+  @Test
+  fun testMarkAllNotificationsForUserAsRead() = runTest {
+    repository.markAllNotificationsForUserAsRead("target1")
+    val updatedNotification1 =
+        FirebaseEmulator.firestore
+            .collection(NOTIFICATION_COLLECTION_PATH)
+            .document("notification1")
+            .get()
+            .await()
+            .toNotification()
+    val updatedNotification2 =
+        FirebaseEmulator.firestore
+            .collection(NOTIFICATION_COLLECTION_PATH)
+            .document("notification2")
+            .get()
+            .await()
+            .toNotification()
+    val updatedNotification3 =
+        FirebaseEmulator.firestore
+            .collection(NOTIFICATION_COLLECTION_PATH)
+            .document("notification3")
+            .get()
+            .await()
+            .toNotification()
+
+    assertTrue(updatedNotification1.isRead)
+    assertFalse(updatedNotification2.isRead)
+    assertTrue(updatedNotification3.isRead)
+  }
+
+  @Test
+  fun testDeleteNotification() = runTest {
+    repository.deleteNotification("notification2")
+    assertFalse(
+        FirebaseEmulator.firestore
+            .collection(NOTIFICATION_COLLECTION_PATH)
+            .document("notification2")
+            .get()
+            .await()
+            .exists())
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testDeleteNonExistentNotification() = runTest {
+    repository.deleteNotification("nonExistentNotification")
+  }
+
+  @Test
+  fun testDeleteAllNotificationsForUser() = runTest {
+    repository.deleteAllNotificationsForUser("target1")
+    assertTrue(
+        FirebaseEmulator.firestore
+            .collection(NOTIFICATION_COLLECTION_PATH)
+            .whereEqualTo("targetId", "target1")
+            .get()
+            .await()
+            .documents
+            .isEmpty())
+  }
+
+  private fun DocumentSnapshot.toNotification(): Notification {
+    val notificationId = id
+    val targetId = getString("targetId") ?: throwMissingFieldException("targetId")
+    val authorId = getString("authorId") ?: throwMissingFieldException("authorId")
+    val title = getString("title") ?: throwMissingFieldException("title")
+    val body = getString("body") ?: throwMissingFieldException("body")
+    val route = getString("route") ?: throwMissingFieldException("route")
+    val isRead = getBoolean("read") ?: throwMissingFieldException("read")
+    val date = getTimestamp("date") ?: throwMissingFieldException("date")
+
+    return Notification(notificationId, targetId, authorId, isRead, title, body, route, date)
+  }
+
+  private fun throwMissingFieldException(field: String): Nothing {
+    throw IllegalArgumentException("Missing required field in Notification: $field")
+  }
+}

--- a/app/src/androidTest/java/com/android/wildex/model/posts/PostsRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/model/posts/PostsRepositoryFirestoreTest.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import com.android.wildex.model.social.PostsRepositoryFirestore
 import com.android.wildex.model.utils.Location
 import com.android.wildex.utils.FirestoreTest
-import com.google.firebase.Timestamp
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
@@ -155,7 +154,7 @@ class PostsRepositoryFirestoreTest : FirestoreTest(POSTS_COLLECTION_PATH) {
                 pictureURL = "Modified PictureURL",
                 location = Location(1.0, 1.0),
                 description = "Modified Description",
-                date = Timestamp.Companion.fromDate(2026, Calendar.JANUARY, 1),
+                date = fromDate(2026, Calendar.JANUARY, 1),
                 animalId = "modifiedAnimalId",
                 likesCount = 20,
                 commentsCount = 10,
@@ -185,7 +184,7 @@ class PostsRepositoryFirestoreTest : FirestoreTest(POSTS_COLLECTION_PATH) {
                 pictureURL = "Modified PictureURL",
                 location = Location(1.0, 1.0),
                 description = "Modified Description",
-                date = Timestamp.Companion.fromDate(2026, Calendar.JANUARY, 1),
+                date = fromDate(2026, Calendar.JANUARY, 1),
                 animalId = "modifiedAnimalId",
                 likesCount = 20,
                 commentsCount = 10,

--- a/app/src/androidTest/java/com/android/wildex/model/user/UserRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/model/user/UserRepositoryFirestoreTest.kt
@@ -3,7 +3,6 @@ package com.android.wildex.model.user
 import android.util.Log
 import com.android.wildex.utils.FirebaseEmulator
 import com.android.wildex.utils.FirestoreTest
-import com.google.firebase.Timestamp
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import java.util.Calendar
@@ -246,7 +245,7 @@ class UserRepositoryFirestoreTest : FirestoreTest(USERS_COLLECTION_PATH) {
   @Test
   fun getUser_withInvalidUserType_fallsBackToRegular() = runTest {
     val id = "invalidUserType"
-    val creationTs = Timestamp.Companion.fromDate(2024, Calendar.JANUARY, 1)
+    val creationTs = fromDate(2024, Calendar.JANUARY, 1)
     FirebaseEmulator.firestore
         .collection(USERS_COLLECTION_PATH)
         .document(id)

--- a/app/src/androidTest/java/com/android/wildex/utils/FirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/utils/FirestoreTest.kt
@@ -56,7 +56,7 @@ open class FirestoreTest(val collectionPath: String) {
     assert(getCount() == 0) { "Test collection is not empty after clearing, count: ${getCount()}" }
   }
 
-  fun Timestamp.Companion.fromDate(year: Int, month: Int, day: Int): Timestamp {
+  fun fromDate(year: Int, month: Int, day: Int): Timestamp {
     val calendar = Calendar.getInstance()
     calendar.set(year, month, day, 0, 0, 0)
     return Timestamp(calendar.time)
@@ -81,7 +81,7 @@ open class FirestoreTest(val collectionPath: String) {
               "https://t4.ftcdn.net/jpg/04/15/79/09/360_F_415790935_7va5lMHOmyhvAcdskXbSx7lDJUp0cfja.jpg",
           location = Location(0.0, 0.0),
           description = "Description 1",
-          date = Timestamp.Companion.fromDate(2025, Calendar.SEPTEMBER, 1),
+          date = fromDate(2025, Calendar.SEPTEMBER, 1),
           animalId = "animal1",
           likesCount = 10,
           commentsCount = 5,
@@ -95,7 +95,7 @@ open class FirestoreTest(val collectionPath: String) {
               "https://t4.ftcdn.net/jpg/04/15/79/09/360_F_415790935_7va5lMHOmyhvAcdskXbSx7lDJUp0cfja.jpg",
           location = Location(0.1, 0.3),
           description = "Description 2",
-          date = Timestamp.Companion.fromDate(2035, Calendar.SEPTEMBER, 4),
+          date = fromDate(2035, Calendar.SEPTEMBER, 4),
           animalId = "animal2",
           likesCount = 10,
           commentsCount = 5,
@@ -109,7 +109,7 @@ open class FirestoreTest(val collectionPath: String) {
               "https://t4.ftcdn.net/jpg/04/15/79/09/360_F_415790935_7va5lMHOmyhvAcdskXbSx7lDJUp0cfja.jpg",
           location = Location(0.3, 0.3),
           description = "Description 3",
-          date = Timestamp.Companion.fromDate(2024, Calendar.SEPTEMBER, 8),
+          date = fromDate(2024, Calendar.SEPTEMBER, 8),
           animalId = "animal3",
           likesCount = 10,
           commentsCount = 5,
@@ -124,7 +124,7 @@ open class FirestoreTest(val collectionPath: String) {
           bio = "Bio 1",
           profilePictureURL = "url1",
           userType = UserType.REGULAR,
-          creationDate = Timestamp.Companion.fromDate(2024, Calendar.JANUARY, 1),
+          creationDate = fromDate(2024, Calendar.JANUARY, 1),
           country = "Country1",
       )
 
@@ -137,7 +137,7 @@ open class FirestoreTest(val collectionPath: String) {
           bio = "Bio 2",
           profilePictureURL = "url2",
           userType = UserType.REGULAR,
-          creationDate = Timestamp.Companion.fromDate(2025, Calendar.FEBRUARY, 2),
+          creationDate = fromDate(2025, Calendar.FEBRUARY, 2),
           country = "Country2",
       )
 
@@ -150,7 +150,7 @@ open class FirestoreTest(val collectionPath: String) {
           bio = "Bio 3",
           profilePictureURL = "url3",
           userType = UserType.REGULAR,
-          creationDate = Timestamp.Companion.fromDate(2023, Calendar.MARCH, 3),
+          creationDate = fromDate(2023, Calendar.MARCH, 3),
           country = "Country3",
       )
 
@@ -166,8 +166,9 @@ open class FirestoreTest(val collectionPath: String) {
           parentId = "parent1",
           authorId = "author1",
           text = "text1",
-          date = Timestamp.fromDate(2003, 11, 21),
-          tag = CommentTag.POST_COMMENT)
+          date = fromDate(2003, 11, 21),
+          tag = CommentTag.POST_COMMENT,
+      )
 
   open val comment2 =
       Comment(
@@ -175,8 +176,9 @@ open class FirestoreTest(val collectionPath: String) {
           parentId = "parent2",
           authorId = "author2",
           text = "text2",
-          date = Timestamp.fromDate(2012, 12, 12),
-          tag = CommentTag.REPORT_COMMENT)
+          date = fromDate(2012, 12, 12),
+          tag = CommentTag.REPORT_COMMENT,
+      )
 
   open val animal1 =
       Animal(
@@ -201,10 +203,11 @@ open class FirestoreTest(val collectionPath: String) {
           reportId = "reportId1",
           imageURL = "imageURL1",
           location = Location(0.3, 0.3),
-          date = Timestamp.fromDate(2017, 4, 29),
+          date = fromDate(2017, 4, 29),
           description = "description1",
           authorId = "authorId1",
-          assigneeId = "assigneeId1")
+          assigneeId = "assigneeId1",
+      )
 
   open val report2 =
       Report(
@@ -214,7 +217,8 @@ open class FirestoreTest(val collectionPath: String) {
           date = Timestamp.now(),
           description = "description2",
           authorId = "authorId2",
-          assigneeId = "assigneeId2")
+          assigneeId = "assigneeId2",
+      )
 
   open val friendRequest1 = FriendRequest(senderId = user1.userId, receiverId = user2.userId)
 

--- a/app/src/main/java/com/android/wildex/model/RepositoryProvider.kt
+++ b/app/src/main/java/com/android/wildex/model/RepositoryProvider.kt
@@ -11,6 +11,8 @@ import com.android.wildex.model.authentication.AuthRepository
 import com.android.wildex.model.authentication.AuthRepositoryFirebase
 import com.android.wildex.model.friendRequest.FriendRequestRepository
 import com.android.wildex.model.friendRequest.FriendRequestRepositoryFirestore
+import com.android.wildex.model.notification.NotificationRepository
+import com.android.wildex.model.notification.NotificationRepositoryFirestore
 import com.android.wildex.model.report.ReportRepository
 import com.android.wildex.model.report.ReportRepositoryFirestore
 import com.android.wildex.model.social.CommentRepository
@@ -60,5 +62,8 @@ object RepositoryProvider {
   }
   val friendRequestRepository: FriendRequestRepository by lazy {
     FriendRequestRepositoryFirestore(Firebase.firestore)
+  }
+  val notificationRepository: NotificationRepository by lazy {
+    NotificationRepositoryFirestore(Firebase.firestore)
   }
 }

--- a/app/src/main/java/com/android/wildex/model/notification/NotificationRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/wildex/model/notification/NotificationRepositoryFirestore.kt
@@ -1,0 +1,72 @@
+package com.android.wildex.model.notification
+
+import com.android.wildex.model.utils.Id
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+class NotificationRepositoryFirestore(db: FirebaseFirestore) : NotificationRepository {
+  companion object {
+    private const val NOTIFICATIONS_COLLECTION_PATH = "notifications"
+    private const val TARGET_ID = "targetId"
+    private const val AUTHOR_ID = "authorId"
+    private const val TITLE = "title"
+    private const val BODY = "body"
+    private const val ROUTE = "route"
+    private const val READ = "read"
+    private const val DATE = "date"
+  }
+
+  private val collection = db.collection(NOTIFICATIONS_COLLECTION_PATH)
+
+  override suspend fun getAllNotificationsForUser(userId: Id): List<Notification> {
+    return collection.whereEqualTo(TARGET_ID, userId).get().await().documents.map {
+      documentToNotification(it)
+    }
+  }
+
+  override suspend fun markNotificationAsRead(notificationId: Id) {
+    val docRef = collection.document(notificationId)
+    require(docRef.get().await().exists()) {
+      "A notification with id '$notificationId' does not exist."
+    }
+    docRef.update(READ, true).await()
+  }
+
+  override suspend fun markAllNotificationsForUserAsRead(userId: Id) {
+    collection.whereEqualTo(TARGET_ID, userId).get().await().documents.forEach {
+      it.reference.update(READ, true).await()
+    }
+  }
+
+  override suspend fun deleteNotification(notificationId: Id) {
+    val docRef = collection.document(notificationId)
+    require(docRef.get().await().exists()) {
+      "A notification with id '$notificationId' does not exist."
+    }
+    docRef.delete().await()
+  }
+
+  override suspend fun deleteAllNotificationsForUser(userId: Id) {
+    collection.whereEqualTo(TARGET_ID, userId).get().await().documents.forEach {
+      it.reference.delete().await()
+    }
+  }
+
+  private fun documentToNotification(document: DocumentSnapshot): Notification {
+    val notificationId = document.id
+    val targetId = document.getString(TARGET_ID) ?: throwMissingFieldException(TARGET_ID)
+    val authorId = document.getString(AUTHOR_ID) ?: throwMissingFieldException(AUTHOR_ID)
+    val title = document.getString(TITLE) ?: throwMissingFieldException(TITLE)
+    val body = document.getString(BODY) ?: throwMissingFieldException(BODY)
+    val route = document.getString(ROUTE) ?: throwMissingFieldException(ROUTE)
+    val isRead = document.getBoolean(READ) ?: throwMissingFieldException(READ)
+    val date = document.getTimestamp(DATE) ?: throwMissingFieldException(DATE)
+
+    return Notification(notificationId, targetId, authorId, isRead, title, body, route, date)
+  }
+
+  private fun throwMissingFieldException(field: String): Nothing {
+    throw IllegalArgumentException("Missing required field in Notification: $field")
+  }
+}

--- a/firebase/storage/storage.rules
+++ b/firebase/storage/storage.rules
@@ -16,7 +16,7 @@ service firebase.storage {
     // all client requests to your Storage bucket will be denied until you Update
     // your rules
     match /{allPaths=**} {
-      allow read, write: if request.time < timestamp.date(2025, 11, 27);
+      allow read, write: if true;
     }
   }
 }


### PR DESCRIPTION
## Description
This PR introduces the Firestore implementation of the notification repository, it also includes comprehensive tests. Other changes include :
* Changed Firebase storage rules to remove time limit, due to fail of  CI on the main branch.
* Removed some redundant calls to `Companion` in some test classes.

## Related issued
Closes #250 