### PR TITLE
refactor: remove likeCount and commentCount from Post data class

### DIFF
--- a/app/src/androidTest/java/com/android/wildex/model/achievement/UserAchievementsRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/model/achievement/UserAchievementsRepositoryFirestoreTest.kt
@@ -11,6 +11,7 @@ import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.test.runTest
@@ -71,10 +72,7 @@ class UserAchievementsRepositoryFirestoreTest : FirestoreTest(USER_ACHIEVEMENTS_
             location = null,
             description = "",
             date = Timestamp.now(),
-            animalId = "",
-            likesCount = 0,
-            commentsCount = 0,
-        )) // For the firstPost achievement
+            animalId = "")) // For the firstPost achievement
     repository.updateUserAchievements(testUserId)
 
     val achievements = repository.getAllAchievementsByUser(testUserId)
@@ -94,10 +92,7 @@ class UserAchievementsRepositoryFirestoreTest : FirestoreTest(USER_ACHIEVEMENTS_
             location = null,
             description = "",
             date = Timestamp.now(),
-            animalId = "",
-            likesCount = 0,
-            commentsCount = 0,
-        )) // For the firstPost achievement
+            animalId = "")) // For the firstPost achievement
     repository.updateUserAchievements(testUserId)
 
     val count = repository.getAchievementsCountOfUser(testUserId)
@@ -105,30 +100,28 @@ class UserAchievementsRepositoryFirestoreTest : FirestoreTest(USER_ACHIEVEMENTS_
   }
 
   @Test
-  fun updateUserAchievementsWhenNoChangesDoesNotUpdate() = runTest {
+  fun updateUserAchievementsWhenNoChangesDoesNotUpdate() =
+      runTest(timeout = 3.minutes) {
 
-    // Setup
-    repository.initializeUserAchievements(testUserId)
-    RepositoryProvider.postRepository.addPost(
-        Post(
-            postId = "post1",
-            authorId = testUserId,
-            pictureURL = "",
-            location = null,
-            description = "",
-            date = Timestamp.now(),
-            animalId = "",
-            likesCount = 0,
-            commentsCount = 0,
-        )) // For the firstPost achievement
-    repository.updateUserAchievements(testUserId)
+        // Setup
+        repository.initializeUserAchievements(testUserId)
+        RepositoryProvider.postRepository.addPost(
+            Post(
+                postId = "post1",
+                authorId = testUserId,
+                pictureURL = "",
+                location = null,
+                description = "",
+                date = Timestamp.now(),
+                animalId = "")) // For the firstPost achievement
+        repository.updateUserAchievements(testUserId)
 
-    val initialAchievements = repository.getAllAchievementsByUser(testUserId)
-    repository.updateUserAchievements(testUserId)
+        val initialAchievements = repository.getAllAchievementsByUser(testUserId)
+        repository.updateUserAchievements(testUserId)
 
-    val updatedAchievements = repository.getAllAchievementsByUser(testUserId)
-    assertEquals(initialAchievements, updatedAchievements)
-  }
+        val updatedAchievements = repository.getAllAchievementsByUser(testUserId)
+        assertEquals(initialAchievements, updatedAchievements)
+      }
 
   @Test
   fun getAllAchievementsByUserWhenEmptyAchievementsReturnsEmptyList() = runTest {

--- a/app/src/androidTest/java/com/android/wildex/model/posts/PostsRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/model/posts/PostsRepositoryFirestoreTest.kt
@@ -155,10 +155,7 @@ class PostsRepositoryFirestoreTest : FirestoreTest(POSTS_COLLECTION_PATH) {
                 location = Location(1.0, 1.0),
                 description = "Modified Description",
                 date = fromDate(2026, Calendar.JANUARY, 1),
-                animalId = "modifiedAnimalId",
-                likesCount = 20,
-                commentsCount = 10,
-            )
+                animalId = "modifiedAnimalId")
         repository.editPost(post1.postId, modifiedPost)
         assertEquals(1, getPostsCount())
         val postsAfterEdit = repository.getAllPosts()
@@ -185,10 +182,7 @@ class PostsRepositoryFirestoreTest : FirestoreTest(POSTS_COLLECTION_PATH) {
                 location = Location(1.0, 1.0),
                 description = "Modified Description",
                 date = fromDate(2026, Calendar.JANUARY, 1),
-                animalId = "modifiedAnimalId",
-                likesCount = 20,
-                commentsCount = 10,
-            )
+                animalId = "modifiedAnimalId")
         repository.editPost(post1.postId, modifiedPost)
         val postsAfterEdit = repository.getAllPosts()
         assertEquals(postsAfterEdit.size, 3)
@@ -274,8 +268,6 @@ class PostsRepositoryFirestoreTest : FirestoreTest(POSTS_COLLECTION_PATH) {
   fun testGetAllPostsByAuthorWhenNoPostsByAuthorExist() =
       runTest(timeout = 60.seconds) {
         Firebase.auth.signInAnonymously().await()
-        val currentUserId =
-            Firebase.auth.currentUser?.uid ?: throw Exception("No current user found")
         val post1 = post1.copy(authorId = "author1")
         val post2 = post2.copy(authorId = "author2")
         repository.addPost(post1)

--- a/app/src/androidTest/java/com/android/wildex/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/map/MapScreenTest.kt
@@ -74,10 +74,7 @@ class MapScreenTest {
           location = Location(46.5197, 6.6323, "Lausanne"),
           description = "A nice post",
           date = Timestamp.now(),
-          animalId = "fox",
-          likesCount = 3,
-          commentsCount = 1,
-      )
+          animalId = "fox")
   private val report1 =
       Report(
           reportId = "r1",
@@ -100,6 +97,7 @@ class MapScreenTest {
 
   private val userRepository = LocalRepositories.userRepository
   private val likeRepository = LocalRepositories.likeRepository
+  private val commentRepository = LocalRepositories.commentRepository
   private val reportRepository = LocalRepositories.reportRepository
   private val postsRepository = LocalRepositories.postsRepository
   private val animalRepository = LocalRepositories.animalRepository
@@ -121,6 +119,7 @@ class MapScreenTest {
             postRepository = postsRepository,
             userRepository = userRepository,
             likeRepository = likeRepository,
+            commentRepository = commentRepository,
             reportRepository = reportRepository,
             animalRepository = animalRepository,
             currentUserId = currentUserId,
@@ -197,11 +196,11 @@ class MapScreenTest {
         requireNotNull(viewModel.uiState.value.pins.firstOrNull { it is MapPin.PostPin }?.id)
     viewModel.onPinSelected(postPinId)
     composeTestRule.waitForIdle()
-    val before = (viewModel.uiState.value.selected as? PinDetails.PostDetails)?.post?.likesCount
+    val before = (viewModel.uiState.value.selected as? PinDetails.PostDetails)?.likeCount
     requireNotNull(before)
     node(MapContentTestTags.SELECTION_LIKE_BUTTON).assertIsDisplayed().performClick()
     composeTestRule.waitForIdle()
-    val after = (viewModel.uiState.value.selected as? PinDetails.PostDetails)?.post?.likesCount
+    val after = (viewModel.uiState.value.selected as? PinDetails.PostDetails)?.likeCount
     requireNotNull(after)
     assert(before != after)
     node(MapContentTestTags.SELECTION_CARD).assertIsDisplayed()
@@ -333,7 +332,13 @@ class MapScreenTest {
     var opened: Id? = null
     var liked: Id? = null
     val details =
-        PinDetails.PostDetails(post = post1, author = null, likedByMe = false, animalName = "fox")
+        PinDetails.PostDetails(
+            post = post1,
+            author = null,
+            likedByMe = false,
+            animalName = "fox",
+            likeCount = 0,
+            commentCount = 0)
     setSelectionCard(
         selection = details,
         tab = MapTab.Posts,
@@ -377,7 +382,8 @@ class MapScreenTest {
                 SimpleUser(user1.userId, user1.username, user1.profilePictureURL, user1.userType),
             likedByMe = true,
             animalName = "owl",
-        )
+            likeCount = 0,
+            commentCount = 0)
     setSelectionCard(selection = details, tab = MapTab.MyPosts)
     nodeText("You saw an owl", substring = true).assertIsDisplayed()
     node(MapContentTestTags.SELECTION_LOCATION).assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/wildex/ui/navigation/NavigationTestUtils.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/navigation/NavigationTestUtils.kt
@@ -141,8 +141,6 @@ abstract class NavigationTestUtils {
           description = "This is my first post",
           date = Timestamp.now(),
           animalId = "0",
-          likesCount = 0,
-          commentsCount = 0,
       )
 
   open val post1 =
@@ -154,8 +152,6 @@ abstract class NavigationTestUtils {
           description = "This my post",
           date = Timestamp.now(),
           animalId = "0",
-          likesCount = 0,
-          commentsCount = 0,
       )
 
   open val animal0 =

--- a/app/src/androidTest/java/com/android/wildex/ui/post/PostDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/post/PostDetailsScreenTest.kt
@@ -142,8 +142,6 @@ class PostDetailsScreenTest {
             description = "Saw this beautiful tiger during my trip!",
             date = Timestamp.now(),
             animalId = "tiger",
-            likesCount = 2,
-            commentsCount = 2,
         )
     postRepository.addPost(post)
 
@@ -328,8 +326,6 @@ class PostDetailsScreenTest {
               description = "",
               date = Timestamp.now(),
               animalId = "",
-              likesCount = 0,
-              commentsCount = 0,
           ))
       val vm =
           PostDetailsScreenViewModel(

--- a/app/src/androidTest/java/com/android/wildex/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/profile/EditProfileScreenTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import com.android.wildex.model.storage.StorageRepository
 import com.android.wildex.model.user.User
 import com.android.wildex.model.user.UserRepository
 import com.android.wildex.model.user.UserType
@@ -33,6 +34,7 @@ class EditProfileScreenTest {
   @get:Rule val composeRule = createComposeRule()
 
   private lateinit var userRepository: UserRepository
+  private lateinit var storageRepository: StorageRepository
 
   private fun sampleUser() =
       User(
@@ -50,6 +52,7 @@ class EditProfileScreenTest {
   @Before
   fun setup() {
     userRepository = LocalRepositories.userRepository
+    storageRepository = LocalRepositories.storageRepository
   }
 
   @After
@@ -61,7 +64,11 @@ class EditProfileScreenTest {
   fun initialState_showsFields_andProfilePreview() {
 
     runBlocking { userRepository.addUser(sampleUser()) }
-    val vm = EditProfileViewModel(userRepository = userRepository, currentUserId = "uid-1")
+    val vm =
+        EditProfileViewModel(
+            userRepository = userRepository,
+            storageRepository = storageRepository,
+            currentUserId = "uid-1")
 
     composeRule.setContent { EditProfileScreen(editScreenViewModel = vm, isNewUser = true) }
     composeRule.waitForIdle()
@@ -82,7 +89,11 @@ class EditProfileScreenTest {
   fun countryDropdown_opens_and_selects_country() {
 
     runBlocking { userRepository.addUser(sampleUser()) }
-    val vm = EditProfileViewModel(userRepository = userRepository, currentUserId = "uid-1")
+    val vm =
+        EditProfileViewModel(
+            userRepository = userRepository,
+            storageRepository = storageRepository,
+            currentUserId = "uid-1")
 
     composeRule.setContent { EditProfileScreen(editScreenViewModel = vm, isNewUser = true) }
     composeRule.waitForIdle()
@@ -121,7 +132,11 @@ class EditProfileScreenTest {
   fun changeProfileImage_updatesPreview() {
 
     runBlocking { userRepository.addUser(sampleUser()) }
-    val vm = EditProfileViewModel(userRepository = userRepository, currentUserId = "uid-1")
+    val vm =
+        EditProfileViewModel(
+            userRepository = userRepository,
+            storageRepository = storageRepository,
+            currentUserId = "uid-1")
 
     composeRule.setContent { EditProfileScreen(editScreenViewModel = vm) }
     composeRule.waitForIdle()
@@ -136,7 +151,11 @@ class EditProfileScreenTest {
   fun goBack_invokes_callback() {
 
     runBlocking { userRepository.addUser(sampleUser()) }
-    val vm = EditProfileViewModel(userRepository = userRepository, currentUserId = "uid-1")
+    val vm =
+        EditProfileViewModel(
+            userRepository = userRepository,
+            storageRepository = storageRepository,
+            currentUserId = "uid-1")
 
     var back = 0
     composeRule.setContent {
@@ -152,7 +171,11 @@ class EditProfileScreenTest {
   @Test
   fun save_click_invokes_onSave_when_isNewUser_true() {
     runBlocking { userRepository.addUser(sampleUser()) }
-    val vm = EditProfileViewModel(userRepository = userRepository, currentUserId = "uid-1")
+    val vm =
+        EditProfileViewModel(
+            userRepository = userRepository,
+            storageRepository = storageRepository,
+            currentUserId = "uid-1")
 
     vm.setName("Jane")
     vm.setSurname("Doe")

--- a/app/src/androidTest/java/com/android/wildex/ui/social/UserRecommenderTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/social/UserRecommenderTest.kt
@@ -38,9 +38,7 @@ class UserRecommenderTest {
           location = Location(0.0, 0.0, ""),
           description = "",
           date = Timestamp.now(),
-          animalId = "",
-          likesCount = 0,
-          commentsCount = 0)
+          animalId = "")
 
   private val userRepository = LocalRepositories.userRepository
   private val userFriendsRepository = LocalRepositories.userFriendsRepository

--- a/app/src/androidTest/java/com/android/wildex/utils/FirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/utils/FirestoreTest.kt
@@ -83,8 +83,6 @@ open class FirestoreTest(val collectionPath: String) {
           description = "Description 1",
           date = fromDate(2025, Calendar.SEPTEMBER, 1),
           animalId = "animal1",
-          likesCount = 10,
-          commentsCount = 5,
       )
 
   open val post2 =
@@ -97,8 +95,6 @@ open class FirestoreTest(val collectionPath: String) {
           description = "Description 2",
           date = fromDate(2035, Calendar.SEPTEMBER, 4),
           animalId = "animal2",
-          likesCount = 10,
-          commentsCount = 5,
       )
 
   open val post3 =
@@ -111,8 +107,6 @@ open class FirestoreTest(val collectionPath: String) {
           description = "Description 3",
           date = fromDate(2024, Calendar.SEPTEMBER, 8),
           animalId = "animal3",
-          likesCount = 10,
-          commentsCount = 5,
       )
 
   open val user1 =

--- a/app/src/main/java/com/android/wildex/model/achievement/Achievements.kt
+++ b/app/src/main/java/com/android/wildex/model/achievement/Achievements.kt
@@ -63,7 +63,9 @@ object Achievements {
           description = "Get 1000 likes across all your posts",
           name = "Influencer",
           condition = { userId ->
-            postRepository.getAllPostsByGivenAuthor(userId).sumOf { it.likesCount } >= 1000
+            postRepository.getAllPostsByGivenAuthor(userId).sumOf {
+              likeRepository.getLikesForPost(it.postId).size
+            } >= 1000
           },
       )
 
@@ -85,7 +87,9 @@ object Achievements {
           description = "Get 100 likes on a single post",
           name = "Rising Star",
           condition = { userId ->
-            postRepository.getAllPostsByGivenAuthor(userId).any { it.likesCount >= 100 }
+            postRepository.getAllPostsByGivenAuthor(userId).any {
+              likeRepository.getLikesForPost(it.postId).size >= 100
+            }
           },
       )
 

--- a/app/src/main/java/com/android/wildex/model/map/Map.kt
+++ b/app/src/main/java/com/android/wildex/model/map/Map.kt
@@ -91,6 +91,8 @@ sealed interface PinDetails {
       val post: Post,
       val author: SimpleUser?,
       val likedByMe: Boolean,
+      val likeCount: Int,
+      val commentCount: Int,
       val animalName: String = "animal",
   ) : PinDetails
 

--- a/app/src/main/java/com/android/wildex/model/social/Post.kt
+++ b/app/src/main/java/com/android/wildex/model/social/Post.kt
@@ -14,8 +14,6 @@ import com.google.firebase.Timestamp
  * @property location The location where the post was made.
  * @property date The date and time when the post was created.
  * @property animalId The ID of the animal related to the post.
- * @property likesCount The number of likes the post has received.
- * @property commentsCount The number of comments the post has received.
  */
 data class Post(
     val postId: Id,
@@ -24,7 +22,5 @@ data class Post(
     val location: Location?,
     val description: String = "",
     val date: Timestamp,
-    val animalId: Id,
-    val likesCount: Int,
-    val commentsCount: Int,
+    val animalId: Id
 )

--- a/app/src/main/java/com/android/wildex/model/social/PostsRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/wildex/model/social/PostsRepositoryFirestore.kt
@@ -104,8 +104,6 @@ class PostsRepositoryFirestore(private val db: FirebaseFirestore) : PostsReposit
       val date = doc.getTimestamp("date") ?: throwMissingFieldException("date")
       val animalId = doc.getString("animalId") ?: throwMissingFieldException("animalId")
       val description = doc.getString("description") ?: ""
-      val likesCount = doc.getLong("likesCount")?.toInt() ?: 0
-      val commentsCount = doc.getLong("commentsCount")?.toInt() ?: 0
 
       Post(
           postId = postId,
@@ -115,8 +113,6 @@ class PostsRepositoryFirestore(private val db: FirebaseFirestore) : PostsReposit
           description = description,
           date = date,
           animalId = animalId,
-          likesCount = likesCount,
-          commentsCount = commentsCount,
       )
     } catch (e: Exception) {
       Log.e("PostsRepositoryFirestore", "Error converting document to Post", e)

--- a/app/src/main/java/com/android/wildex/ui/camera/CameraScreenViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/camera/CameraScreenViewModel.kt
@@ -113,8 +113,6 @@ class CameraScreenViewModel(
                 date = Timestamp.now(),
                 pictureURL = imageUrl,
                 animalId = animalId,
-                likesCount = 0,
-                commentsCount = 0,
             )
         postsRepository.addPost(finalPost)
         registerAnimal(animalId, context)

--- a/app/src/main/java/com/android/wildex/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/android/wildex/ui/home/HomeScreen.kt
@@ -132,29 +132,30 @@ fun HomeScreen(
   Scaffold(
       topBar = { HomeTopBar(user, onNotificationClick, onProfilePictureClick) },
       bottomBar = { bottomBar() },
-      modifier = Modifier.testTag(NavigationTestTags.HOME_SCREEN)) { pd ->
-        val pullState = rememberPullToRefreshState()
+      modifier = Modifier.testTag(NavigationTestTags.HOME_SCREEN),
+  ) { pd ->
+    val pullState = rememberPullToRefreshState()
 
-        PullToRefreshBox(
-            state = pullState,
-            isRefreshing = uiState.isRefreshing,
-            modifier = Modifier.padding(pd),
-            onRefresh = { homeScreenViewModel.refreshUIState() },
-        ) {
-          when {
-            uiState.isError -> LoadingFail()
-            uiState.isLoading -> LoadingScreen()
-            postStates.isEmpty() -> NoPostsView()
-            else ->
-                PostsView(
-                    postStates = postStates,
-                    onProfilePictureClick = onProfilePictureClick,
-                    onPostLike = homeScreenViewModel::toggleLike,
-                    onPostClick = onPostClick,
-                )
-          }
-        }
+    PullToRefreshBox(
+        state = pullState,
+        isRefreshing = uiState.isRefreshing,
+        modifier = Modifier.padding(pd),
+        onRefresh = { homeScreenViewModel.refreshUIState() },
+    ) {
+      when {
+        uiState.isError -> LoadingFail()
+        uiState.isLoading -> LoadingScreen()
+        postStates.isEmpty() -> NoPostsView()
+        else ->
+            PostsView(
+                postStates = postStates,
+                onProfilePictureClick = onProfilePictureClick,
+                onPostLike = homeScreenViewModel::toggleLike,
+                onPostClick = onPostClick,
+            )
       }
+    }
+  }
 }
 
 /** Displays a placeholder view when there are no posts available. */
@@ -224,7 +225,7 @@ fun PostItem(
     postState: PostState,
     onProfilePictureClick: (userId: Id) -> Unit = {},
     onPostLike: (Id) -> Unit,
-    onPostClick: (Id) -> Unit
+    onPostClick: (Id) -> Unit,
 ) {
   val colorScheme = colorScheme
   val post = postState.post
@@ -233,7 +234,9 @@ fun PostItem(
 
   // -------- Optimistic Like State (instant UI) --------
   var liked by remember(post.postId) { mutableStateOf(postState.isLiked) }
-  var likeCount by remember(post.postId) { mutableIntStateOf(post.likesCount) }
+  var likeCount by remember(post.postId) { mutableIntStateOf(postState.likeCount) }
+  var commentCount by remember(post.postId) { mutableIntStateOf(postState.commentsCount) }
+
   val heartScale by
       animateFloatAsState(
           targetValue = if (liked) 1.1f else 1f,
@@ -393,7 +396,7 @@ fun PostItem(
         )
         Spacer(Modifier.width(6.dp))
         Text(
-            text = commentText(post.commentsCount),
+            text = commentText(commentCount),
             style = typography.bodyMedium,
             color = colorScheme.onBackground,
             maxLines = 1,

--- a/app/src/main/java/com/android/wildex/ui/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/home/HomeScreenViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.wildex.model.RepositoryProvider
 import com.android.wildex.model.animal.AnimalRepository
+import com.android.wildex.model.social.CommentRepository
 import com.android.wildex.model.social.Like
 import com.android.wildex.model.social.LikeRepository
 import com.android.wildex.model.social.Post
@@ -50,7 +51,9 @@ private val defaultUser: SimpleUser =
         userId = "defaultUserId",
         username = "defaultUsername",
         profilePictureURL = "",
-        userType = UserType.REGULAR)
+        userType = UserType.REGULAR,
+    )
+
 /**
  * Combines post data with associated metadata for display.
  *
@@ -64,6 +67,8 @@ data class PostState(
     val isLiked: Boolean,
     val author: SimpleUser,
     val animalName: String,
+    val likeCount: Int,
+    val commentsCount: Int,
 )
 
 /**
@@ -83,6 +88,7 @@ class HomeScreenViewModel(
     private val postRepository: PostsRepository = RepositoryProvider.postRepository,
     private val userRepository: UserRepository = RepositoryProvider.userRepository,
     private val likeRepository: LikeRepository = RepositoryProvider.likeRepository,
+    private val commentRepository: CommentRepository = RepositoryProvider.commentRepository,
     private val animalRepository: AnimalRepository = RepositoryProvider.animalRepository,
     private val currentUserId: Id = Firebase.auth.uid ?: "",
 ) : ViewModel() {
@@ -140,12 +146,16 @@ class HomeScreenViewModel(
               val author = userRepository.getSimpleUser(post.authorId)
               val isLiked = likeRepository.getLikeForPost(post.postId) != null
               val animalName = animalRepository.getAnimal(post.animalId).name
+              val likeCount = likeRepository.getLikesForPost(post.postId).size
+              val commentCount = commentRepository.getAllCommentsByPost(post.postId).size
 
               PostState(
                   post = post,
                   author = author,
                   isLiked = isLiked,
                   animalName = animalName,
+                  likeCount = likeCount,
+                  commentsCount = commentCount,
               )
             } catch (_: Exception) {
               null

--- a/app/src/main/java/com/android/wildex/ui/map/SelectionBottomCard.kt
+++ b/app/src/main/java/com/android/wildex/ui/map/SelectionBottomCard.kt
@@ -258,7 +258,7 @@ private fun PostSelectionCard(
         }
 
         Text(
-            text = details.post.likesCount.toString(),
+            text = details.likeCount.toString(),
             style = typography.bodySmall,
             color = ui.fg,
         )
@@ -276,7 +276,7 @@ private fun PostSelectionCard(
         )
 
         Text(
-            text = details.post.commentsCount.toString(),
+            text = details.commentCount.toString(),
             style = typography.bodySmall,
             color = ui.fg,
         )

--- a/app/src/test/java/com/android/wildex/dataClasses/DataClassesTest.kt
+++ b/app/src/test/java/com/android/wildex/dataClasses/DataClassesTest.kt
@@ -139,8 +139,6 @@ class DataClassesTest {
             description = "Post description",
             date = Timestamp.now(),
             animalId = "animal1",
-            likesCount = 10,
-            commentsCount = 5,
         )
 
     TestCase.assertEquals("post1", post.postId)
@@ -148,8 +146,6 @@ class DataClassesTest {
     TestCase.assertEquals("https://example.com/post_pic", post.pictureURL)
     TestCase.assertEquals("Post Location", post.location?.name)
     TestCase.assertEquals("Post description", post.description)
-    TestCase.assertEquals(10, post.likesCount)
-    TestCase.assertEquals(5, post.commentsCount)
   }
 
   @Test

--- a/app/src/test/java/com/android/wildex/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/home/HomeScreenViewModelTest.kt
@@ -3,6 +3,9 @@ package com.android.wildex.ui.home
 
 import com.android.wildex.model.animal.Animal
 import com.android.wildex.model.animal.AnimalRepository
+import com.android.wildex.model.social.Comment
+import com.android.wildex.model.social.CommentRepository
+import com.android.wildex.model.social.CommentTag
 import com.android.wildex.model.social.Like
 import com.android.wildex.model.social.LikeRepository
 import com.android.wildex.model.social.Post
@@ -32,6 +35,7 @@ class HomeScreenViewModelTest {
   private lateinit var postsRepository: PostsRepository
   private lateinit var userRepository: UserRepository
   private lateinit var likeRepository: LikeRepository
+  private lateinit var commentRepository: CommentRepository
   private lateinit var animalRepository: AnimalRepository
   private lateinit var viewModel: HomeScreenViewModel
 
@@ -40,7 +44,8 @@ class HomeScreenViewModelTest {
           userId = "defaultUserId",
           username = "defaultUsername",
           profilePictureURL = "",
-          userType = UserType.REGULAR)
+          userType = UserType.REGULAR,
+      )
 
   private val p1 =
       Post(
@@ -51,8 +56,6 @@ class HomeScreenViewModelTest {
           description = "d1",
           date = Timestamp(Calendar.getInstance().time),
           animalId = "a1",
-          likesCount = 1,
-          commentsCount = 0,
       )
 
   private val p2 =
@@ -64,8 +67,6 @@ class HomeScreenViewModelTest {
           description = "d2",
           date = Timestamp(Calendar.getInstance().time),
           animalId = "a2",
-          likesCount = 2,
-          commentsCount = 1,
       )
 
   private val u1 =
@@ -73,7 +74,8 @@ class HomeScreenViewModelTest {
           userId = "uid-1",
           username = "user_one",
           profilePictureURL = "u",
-          userType = UserType.REGULAR)
+          userType = UserType.REGULAR,
+      )
 
   private val author1 = SimpleUser("author1", "author_one", "url1", userType = UserType.REGULAR)
   private val author2 = SimpleUser("author2", "author_two", "url2", userType = UserType.REGULAR)
@@ -81,6 +83,25 @@ class HomeScreenViewModelTest {
   private val like1 = Like(likeId = "like1", postId = "p1", userId = "author-2")
 
   private val like2 = Like(likeId = "like2", postId = "p2", userId = "author-1")
+
+  private val comment1 =
+      Comment(
+          commentId = "comment1",
+          parentId = "p1",
+          authorId = "author2",
+          text = "text1",
+          date = Timestamp(Calendar.getInstance().time),
+          tag = CommentTag.POST_COMMENT,
+      )
+  private val comment2 =
+      Comment(
+          commentId = "comment2",
+          parentId = "p2",
+          authorId = "author1",
+          text = "text2",
+          date = Timestamp(Calendar.getInstance().time),
+          tag = CommentTag.POST_COMMENT,
+      )
 
   private val animal1 =
       Animal(
@@ -105,12 +126,14 @@ class HomeScreenViewModelTest {
     postsRepository = mockk()
     userRepository = mockk()
     likeRepository = mockk()
+    commentRepository = mockk()
     animalRepository = mockk()
     viewModel =
         HomeScreenViewModel(
             postsRepository,
             userRepository,
             likeRepository,
+            commentRepository,
             animalRepository,
             "uid-1",
         )
@@ -118,6 +141,10 @@ class HomeScreenViewModelTest {
     coEvery { userRepository.getSimpleUser("author2") } returns author2
     coEvery { likeRepository.getLikeForPost("p1") } returns null
     coEvery { likeRepository.getLikeForPost("p2") } returns null
+    coEvery { likeRepository.getLikesForPost("p1") } returns listOf(like1)
+    coEvery { likeRepository.getLikesForPost("p2") } returns listOf(like2)
+    coEvery { commentRepository.getAllCommentsByPost("p1") } returns listOf(comment1)
+    coEvery { commentRepository.getAllCommentsByPost("p2") } returns listOf(comment2)
     coEvery { animalRepository.getAnimal("a1") } returns animal1
     coEvery { animalRepository.getAnimal("a2") } returns animal2
   }
@@ -148,8 +175,20 @@ class HomeScreenViewModelTest {
       advanceUntilIdle()
       val expectedStates =
           listOf(
-              PostState(p1, isLiked = true, author = author1, animalName = animal1.name),
-              PostState(p2, isLiked = false, author = author2, animalName = animal2.name),
+              PostState(
+                  p1,
+                  isLiked = true,
+                  author = author1,
+                  animalName = animal1.name,
+                  likeCount = 1,
+                  commentsCount = 1),
+              PostState(
+                  p2,
+                  isLiked = false,
+                  author = author2,
+                  animalName = animal2.name,
+                  likeCount = 1,
+                  commentsCount = 1),
           )
       val updatedState = viewModel.uiState.value
       Assert.assertEquals(expectedStates, updatedState.postStates)
@@ -175,8 +214,20 @@ class HomeScreenViewModelTest {
       advanceUntilIdle()
       val expectedStates =
           listOf(
-              PostState(p1, isLiked = true, author = author1, animalName = animal1.name),
-              PostState(p2, isLiked = false, author = author2, animalName = animal2.name),
+              PostState(
+                  p1,
+                  isLiked = true,
+                  author = author1,
+                  animalName = animal1.name,
+                  likeCount = 1,
+                  commentsCount = 1),
+              PostState(
+                  p2,
+                  isLiked = false,
+                  author = author2,
+                  animalName = animal2.name,
+                  likeCount = 1,
+                  commentsCount = 1),
           )
       val updatedState = viewModel.uiState.value
       Assert.assertEquals(expectedStates, updatedState.postStates)
@@ -211,7 +262,13 @@ class HomeScreenViewModelTest {
       coEvery { postsRepository.getAllPosts() } returns listOf(p1)
 
       viewModel =
-          HomeScreenViewModel(postsRepository, userRepository, likeRepository, animalRepository, "")
+          HomeScreenViewModel(
+              postsRepository,
+              userRepository,
+              likeRepository,
+              commentRepository,
+              animalRepository,
+              "")
       viewModel.refreshUIState()
       advanceUntilIdle()
 
@@ -267,7 +324,13 @@ class HomeScreenViewModelTest {
       val s = viewModel.uiState.value
       val expectedStates =
           listOf(
-              PostState(p2, isLiked = true, author = author2, animalName = animal2.name),
+              PostState(
+                  p2,
+                  isLiked = true,
+                  author = author2,
+                  animalName = animal2.name,
+                  likeCount = 1,
+                  commentsCount = 1),
           )
       Assert.assertEquals(expectedStates, s.postStates)
       Assert.assertEquals(u2, s.currentUser)
@@ -326,8 +389,16 @@ class HomeScreenViewModelTest {
       Assert.assertFalse(s.isLoading)
       Assert.assertNull(s.errorMsg)
       Assert.assertEquals(
-          listOf(PostState(p1, isLiked = false, author = author1, animalName = animal1.name)),
-          s.postStates)
+          listOf(
+              PostState(
+                  p1,
+                  isLiked = false,
+                  author = author1,
+                  animalName = animal1.name,
+                  likeCount = 1,
+                  commentsCount = 1)),
+          s.postStates,
+      )
     }
   }
 


### PR DESCRIPTION
## Description
This PR aims to revisit the `Post` data class design choice. We decided it would be best to remove the `likeCount` and `commentCount` fields from the `Post` since it adds unnecessary complexity and adds more work than it avoids, mainly due to the constant need to sync up the posts whenever likes and comments are added or deleted. Since it is a very commonly used class, practically the whole codebase needed refactoring, code and tests.

## Related issues
Closes #331