### PR TITLE
feat: implement userTokens repository for firestore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -259,6 +259,7 @@ dependencies {
   implementation(libs.camera.camera2)
   implementation(libs.camera.lifecycle)
   implementation(libs.guava)
+  implementation(libs.firebase.messaging)
 
   // Lottie
   implementation(libs.lottie.compose)

--- a/app/src/androidTest/java/com/android/wildex/model/user/UserTokensRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/model/user/UserTokensRepositoryFirestoreTest.kt
@@ -1,0 +1,143 @@
+package com.android.wildex.model.user
+
+import com.android.wildex.utils.FirebaseEmulator
+import com.android.wildex.utils.FirestoreTest
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+private const val USER_TOKENS_COLLECTION_PATH = "userTokens"
+
+class UserTokensRepositoryFirestoreTest : FirestoreTest(USER_TOKENS_COLLECTION_PATH) {
+  private val repository = UserTokensRepositoryFirestore(FirebaseEmulator.firestore)
+
+  val userTokens1 = UserTokens(userId = "user1", tokens = listOf("token1", "token2"))
+
+  val userTokens2 = UserTokens(userId = "user2", tokens = listOf("token3", "token4", "token5"))
+
+  val userTokens3 = UserTokens(userId = "user3", tokens = listOf("token6"))
+
+  @Before
+  fun setup() {
+    super.setUp()
+    runBlocking {
+      FirebaseEmulator.firestore
+          .collection(USER_TOKENS_COLLECTION_PATH)
+          .document(userTokens1.userId)
+          .set(userTokens1)
+          .await()
+      FirebaseEmulator.firestore
+          .collection(USER_TOKENS_COLLECTION_PATH)
+          .document(userTokens2.userId)
+          .set(userTokens2)
+          .await()
+      FirebaseEmulator.firestore
+          .collection(USER_TOKENS_COLLECTION_PATH)
+          .document(userTokens3.userId)
+          .set(userTokens3)
+          .await()
+    }
+  }
+
+  @Test
+  fun testInitializeUserTokens() = runTest {
+    val newUserId = "newUserId"
+    assertFalse(
+        FirebaseEmulator.firestore
+            .collection(USER_TOKENS_COLLECTION_PATH)
+            .document(newUserId)
+            .get()
+            .await()
+            .exists())
+    repository.initializeUserTokens(newUserId)
+    val userTokensSnapshot =
+        FirebaseEmulator.firestore
+            .collection(USER_TOKENS_COLLECTION_PATH)
+            .document(newUserId)
+            .get()
+            .await()
+    assertTrue(userTokensSnapshot.exists())
+    assertEquals(
+        userTokensSnapshot.toObject(UserTokens::class.java),
+        UserTokens(userId = newUserId),
+    )
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testInitializeUserTokens_ExistingUserId() = runTest {
+    repository.initializeUserTokens("user1")
+  }
+
+  @Test
+  fun testGetAllTokensOfUser() = runTest {
+    val tokens = repository.getAllTokensOfUser("user1")
+    assertEquals(listOf("token1", "token2"), tokens)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testGetAllTokensOfUser_MissingUserId() = runTest {
+    repository.getAllTokensOfUser("nonExistentUserId")
+  }
+
+  @Test
+  fun testAddTokenToUser() = runTest {
+    val newToken = "newToken"
+    repository.addTokenToUser("user1", newToken)
+    assertEquals(
+        UserTokens("user1", listOf("token1", "token2", newToken)),
+        FirebaseEmulator.firestore
+            .collection(USER_TOKENS_COLLECTION_PATH)
+            .document("user1")
+            .get()
+            .await()
+            .toObject(UserTokens::class.java),
+    )
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testAddTokenToUser_MissingUserId() = runTest {
+    repository.addTokenToUser("nonExistentUserId", "newToken")
+  }
+
+  @Test
+  fun testDeleteTokenOfUser() = runTest {
+    val tokenToDelete = "token2"
+    repository.deleteTokenOfUser("user1", tokenToDelete)
+    assertEquals(
+        UserTokens("user1", listOf("token1")),
+        FirebaseEmulator.firestore
+            .collection(USER_TOKENS_COLLECTION_PATH)
+            .document("user1")
+            .get()
+            .await()
+            .toObject(UserTokens::class.java),
+    )
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testDeleteTokenOfUser_MissingUserId() = runTest {
+    repository.deleteTokenOfUser("nonExistentUserId", "tokenToDelete")
+  }
+
+  @Test
+  fun testDeleteUserTokens() = runTest {
+    repository.deleteUserTokens("user1")
+    assertFalse(
+        FirebaseEmulator.firestore
+            .collection(USER_TOKENS_COLLECTION_PATH)
+            .document("user1")
+            .get()
+            .await()
+            .exists())
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testDeleteUserTokens_MissingUserId() = runTest {
+    repository.deleteUserTokens("nonExistentUserId")
+  }
+}

--- a/app/src/androidTest/java/com/android/wildex/ui/authentication/SignInViewModelTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/authentication/SignInViewModelTest.kt
@@ -17,6 +17,7 @@ import com.android.wildex.model.user.UserAnimalsRepository
 import com.android.wildex.model.user.UserFriendsRepository
 import com.android.wildex.model.user.UserRepository
 import com.android.wildex.model.user.UserSettingsRepository
+import com.android.wildex.model.user.UserTokensRepository
 import com.android.wildex.model.user.UserType
 import com.android.wildex.usecase.user.InitializeUserUseCase
 import com.android.wildex.utils.FakeCredentialManager
@@ -64,6 +65,7 @@ class SignInViewModelTest {
   private lateinit var userAchievementsRepository: UserAchievementsRepository
   private lateinit var userFriendsRepository: UserFriendsRepository
   private lateinit var userSettingsRepository: UserSettingsRepository
+  private lateinit var userTokensRepository: UserTokensRepository
   private val fakeUserIdToken = "fakeUserIdToken"
   private val testDispatcher = StandardTestDispatcher()
 
@@ -82,13 +84,15 @@ class SignInViewModelTest {
     userAchievementsRepository = LocalRepositories.userAchievementsRepository
     userFriendsRepository = LocalRepositories.userFriendsRepository
     userSettingsRepository = LocalRepositories.userSettingsRepository
+    userTokensRepository = LocalRepositories.userTokensRepository
     val initializeUserUseCase =
         InitializeUserUseCase(
             userRepository,
             userSettingsRepository,
             userAnimalsRepository,
             userAchievementsRepository,
-            userFriendsRepository)
+            userFriendsRepository,
+            userTokensRepository)
     authRepository = mockk(relaxed = true)
     credentialManager = FakeCredentialManager.create("fakeToken")
     viewModel =
@@ -96,6 +100,7 @@ class SignInViewModelTest {
             authRepository,
             userRepository,
             userSettingsRepository,
+            userTokensRepository,
             initializeUserUseCase,
         )
   }
@@ -161,6 +166,8 @@ class SignInViewModelTest {
         userAchievementsRepository.initializeUserAchievements(user.userId)
         userSettingsRepository.initializeUserSettings(user.userId)
         userAnimalsRepository.initializeUserAnimals(user.userId)
+        userTokensRepository.initializeUserTokens(user.userId)
+        userFriendsRepository.initializeUserFriends(user.userId)
       }
 
       val fakeCredential =

--- a/app/src/androidTest/java/com/android/wildex/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/settings/SettingsScreenTest.kt
@@ -32,6 +32,7 @@ class SettingsScreenTest {
 
   private val userAchievementsRepository = LocalRepositories.userAchievementsRepository
   private val userFriendsRepository = LocalRepositories.userFriendsRepository
+  private val userTokensRepository = LocalRepositories.userTokensRepository
   private val friendRequestRepository = LocalRepositories.friendRequestRepository
   private val postsRepository = LocalRepositories.postsRepository
   private val reportsRepository = LocalRepositories.reportRepository
@@ -61,12 +62,14 @@ class SettingsScreenTest {
     userAnimalsRepository.initializeUserAnimals("currentUserId")
     userAchievementsRepository.initializeUserAchievements("currentUserId")
     userFriendsRepository.initializeUserFriends("currentUserId")
+    userTokensRepository.initializeUserTokens("currentUserId")
 
     userSettingsScreenVM =
         SettingsScreenViewModel(
             authRepository = authRepository,
             userRepository = userRepository,
             userSettingsRepository = userSettingsRepository,
+            userTokensRepository = userTokensRepository,
             currentUserId = "currentUserId",
             deleteUserUseCase =
                 DeleteUserUseCase(
@@ -76,6 +79,7 @@ class SettingsScreenTest {
                     userAnimalsRepository = userAnimalsRepository,
                     userAchievementsRepository = userAchievementsRepository,
                     userFriendsRepository = userFriendsRepository,
+                    userTokensRepository = userTokensRepository,
                     friendRequestRepository = friendRequestRepository,
                     postsRepository = postsRepository,
                     likeRepository = likesRepository,

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.CAMERA" />
     <!-- Include this permission to grab user's general location -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
@@ -32,6 +33,19 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".model.notification.NotificationServiceFirebase"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/app_logo_foreground" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/green" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/android/wildex/model/RepositoryProvider.kt
+++ b/app/src/main/java/com/android/wildex/model/RepositoryProvider.kt
@@ -31,6 +31,8 @@ import com.android.wildex.model.user.UserRepository
 import com.android.wildex.model.user.UserRepositoryFirestore
 import com.android.wildex.model.user.UserSettingsRepository
 import com.android.wildex.model.user.UserSettingsRepositoryFirestore
+import com.android.wildex.model.user.UserTokensRepository
+import com.android.wildex.model.user.UserTokensRepositoryFirestore
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
@@ -70,5 +72,8 @@ object RepositoryProvider {
   }
   val notificationRepository: NotificationRepository by lazy {
     NotificationRepositoryFirestore(Firebase.firestore)
+  }
+  val userTokensRepository: UserTokensRepository by lazy {
+    UserTokensRepositoryFirestore(Firebase.firestore)
   }
 }

--- a/app/src/main/java/com/android/wildex/model/notification/NotificationServiceFirebase.kt
+++ b/app/src/main/java/com/android/wildex/model/notification/NotificationServiceFirebase.kt
@@ -1,0 +1,21 @@
+package com.android.wildex.model.notification
+
+import com.android.wildex.model.RepositoryProvider
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
+import com.google.firebase.messaging.FirebaseMessagingService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class NotificationServiceFirebase : FirebaseMessagingService() {
+
+  override fun onNewToken(token: String) {
+    super.onNewToken(token)
+    CoroutineScope(Dispatchers.IO).launch {
+      Firebase.auth.currentUser?.apply {
+        RepositoryProvider.userTokensRepository.addTokenToUser(uid, token)
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/android/wildex/model/user/User.kt
+++ b/app/src/main/java/com/android/wildex/model/user/User.kt
@@ -69,6 +69,14 @@ data class UserFriends(
 )
 
 /**
+ * Represents a summary of a user's tokens.
+ *
+ * @property userId The unique identifier of the user to whom these tokens belong.
+ * @property tokens A list of unique identifiers for the tokens the user has.
+ */
+data class UserTokens(val userId: Id = "", val tokens: List<String> = emptyList())
+
+/**
  * Represents the settings of a user.
  *
  * @property userId The unique identifier of the user to whom these settings belong.
@@ -80,7 +88,7 @@ data class UserFriends(
 data class UserSettings(
     val userId: Id = "",
     val enableNotifications: Boolean = true,
-    val appearanceMode: AppearanceMode = AppearanceMode.AUTOMATIC
+    val appearanceMode: AppearanceMode = AppearanceMode.AUTOMATIC,
 )
 
 /** Enum class representing the appearance mode preference of a user. */

--- a/app/src/main/java/com/android/wildex/model/user/UserTokensRepository.kt
+++ b/app/src/main/java/com/android/wildex/model/user/UserTokensRepository.kt
@@ -1,0 +1,24 @@
+package com.android.wildex.model.user
+
+import com.android.wildex.model.utils.Id
+
+interface UserTokensRepository {
+
+  /** Retrieves the current token for a user. */
+  suspend fun getCurrentToken(): String
+
+  /** Initializes UserTokens for a new User with empty list and zero count. */
+  suspend fun initializeUserTokens(userId: Id)
+
+  /** Retrieves UserTokens associated with a specific User. */
+  suspend fun getAllTokensOfUser(userId: Id): List<String>
+
+  /** Add an token to the UserTokens of a specific User. */
+  suspend fun addTokenToUser(userId: Id, token: String)
+
+  /** Delete an token to the UserTokens of a specific User. */
+  suspend fun deleteTokenOfUser(userId: Id, token: String)
+
+  /** Delete the UserTokens linked to the given user */
+  suspend fun deleteUserTokens(userId: Id)
+}

--- a/app/src/main/java/com/android/wildex/model/user/UserTokensRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/wildex/model/user/UserTokensRepositoryFirestore.kt
@@ -1,0 +1,54 @@
+package com.android.wildex.model.user
+
+import com.android.wildex.model.utils.Id
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.messaging.messaging
+import kotlinx.coroutines.tasks.await
+
+class UserTokensRepositoryFirestore(db: FirebaseFirestore) : UserTokensRepository {
+  companion object {
+    private const val USER_TOKENS_COLLECTION_PATH = "userTokens"
+  }
+
+  private val collection = db.collection(USER_TOKENS_COLLECTION_PATH)
+
+  override suspend fun getCurrentToken(): String = Firebase.messaging.token.await()
+
+  override suspend fun initializeUserTokens(userId: Id) {
+    val docRef = collection.document(userId)
+    val snapshot = docRef.get().await()
+    require(!snapshot.exists()) { "A userTokens with userId '${userId}' already exists." }
+    docRef.set(UserTokens(userId = userId, tokens = emptyList())).await()
+  }
+
+  override suspend fun getAllTokensOfUser(userId: Id): List<String> {
+    val docRef = collection.document(userId)
+    val doc = docRef.get().await().toObject(UserTokens::class.java)
+    require(doc != null) { "A userTokens with userId '${userId}' does not exist." }
+    return doc.tokens
+  }
+
+  override suspend fun addTokenToUser(userId: Id, token: String) {
+    val docRef = collection.document(userId)
+    val doc = docRef.get().await().toObject(UserTokens::class.java)
+    require(doc != null) { "A userTokens with userId '${userId}' does not exist." }
+    val newTokens = doc.tokens.toMutableSet().apply { add(token) }.toList()
+    docRef.set(UserTokens(userId = userId, tokens = newTokens)).await()
+  }
+
+  override suspend fun deleteTokenOfUser(userId: Id, token: String) {
+    val docRef = collection.document(userId)
+    val doc = docRef.get().await().toObject(UserTokens::class.java)
+    require(doc != null) { "A userTokens with userId '${userId}' does not exist." }
+    val newTokens = doc.tokens.toMutableList().apply { remove(token) }
+    docRef.set(UserTokens(userId = userId, tokens = newTokens)).await()
+  }
+
+  override suspend fun deleteUserTokens(userId: Id) {
+    val docRef = collection.document(userId)
+    val doc = docRef.get().await().toObject(UserTokens::class.java)
+    require(doc != null) { "A userTokens with userId '${userId}' does not exist." }
+    docRef.delete().await()
+  }
+}

--- a/app/src/main/java/com/android/wildex/ui/settings/SettingsScreenViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/settings/SettingsScreenViewModel.kt
@@ -7,6 +7,7 @@ import com.android.wildex.model.authentication.AuthRepository
 import com.android.wildex.model.user.AppearanceMode
 import com.android.wildex.model.user.UserRepository
 import com.android.wildex.model.user.UserSettingsRepository
+import com.android.wildex.model.user.UserTokensRepository
 import com.android.wildex.model.user.UserType
 import com.android.wildex.model.utils.Id
 import com.android.wildex.usecase.user.DeleteUserUseCase
@@ -31,6 +32,8 @@ class SettingsScreenViewModel(
     private val userSettingsRepository: UserSettingsRepository =
         RepositoryProvider.userSettingsRepository,
     private val userRepository: UserRepository = RepositoryProvider.userRepository,
+    private val userTokensRepository: UserTokensRepository =
+        RepositoryProvider.userTokensRepository,
     private val currentUserId: Id = Firebase.auth.uid ?: "",
     private val deleteUserUseCase: DeleteUserUseCase = DeleteUserUseCase(),
 ) : ViewModel() {
@@ -130,6 +133,7 @@ class SettingsScreenViewModel(
 
   fun signOut(onSignOut: () -> Unit) {
     viewModelScope.launch {
+      userTokensRepository.deleteTokenOfUser(currentUserId, userTokensRepository.getCurrentToken())
       authRepository
           .signOut()
           .fold(

--- a/app/src/main/java/com/android/wildex/usecase/user/DeleteUserUseCase.kt
+++ b/app/src/main/java/com/android/wildex/usecase/user/DeleteUserUseCase.kt
@@ -12,6 +12,7 @@ import com.android.wildex.model.user.UserAnimalsRepository
 import com.android.wildex.model.user.UserFriendsRepository
 import com.android.wildex.model.user.UserRepository
 import com.android.wildex.model.user.UserSettingsRepository
+import com.android.wildex.model.user.UserTokensRepository
 import com.android.wildex.model.utils.Id
 
 /**
@@ -37,6 +38,8 @@ class DeleteUserUseCase(
     private val likeRepository: LikeRepository = RepositoryProvider.likeRepository,
     private val commentRepository: CommentRepository = RepositoryProvider.commentRepository,
     private val authRepository: AuthRepository = RepositoryProvider.authRepository,
+    private val userTokensRepository: UserTokensRepository =
+        RepositoryProvider.userTokensRepository,
 ) {
 
   /**
@@ -56,5 +59,6 @@ class DeleteUserUseCase(
     likeRepository.deleteLikesByUser(userId)
     commentRepository.deleteCommentsByUser(userId)
     authRepository.deleteUserAuth()
+    userTokensRepository.deleteUserTokens(userId)
   }
 }

--- a/app/src/main/java/com/android/wildex/usecase/user/InitializeUserUseCase.kt
+++ b/app/src/main/java/com/android/wildex/usecase/user/InitializeUserUseCase.kt
@@ -7,6 +7,7 @@ import com.android.wildex.model.user.UserAnimalsRepository
 import com.android.wildex.model.user.UserFriendsRepository
 import com.android.wildex.model.user.UserRepository
 import com.android.wildex.model.user.UserSettingsRepository
+import com.android.wildex.model.user.UserTokensRepository
 import com.android.wildex.model.user.UserType
 import com.android.wildex.model.utils.Id
 import com.google.firebase.Timestamp
@@ -26,7 +27,9 @@ class InitializeUserUseCase(
     private val userAchievementsRepository: UserAchievementsRepository =
         RepositoryProvider.userAchievementsRepository,
     private val userFriendsRepository: UserFriendsRepository =
-        RepositoryProvider.userFriendsRepository
+        RepositoryProvider.userFriendsRepository,
+    private val userTokensRepository: UserTokensRepository =
+        RepositoryProvider.userTokensRepository,
 ) {
 
   /**
@@ -41,5 +44,6 @@ class InitializeUserUseCase(
     userAnimalsRepository.initializeUserAnimals(userId)
     userAchievementsRepository.initializeUserAchievements(userId)
     userFriendsRepository.initializeUserFriends(userId)
+    userTokensRepository.initializeUserTokens(userId)
   }
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="green">#FF2e6f40</color>
 </resources>

--- a/app/src/test/java/com/android/wildex/ui/settings/SettingsScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/settings/SettingsScreenViewModelTest.kt
@@ -13,6 +13,7 @@ import com.android.wildex.model.user.UserAnimalsRepository
 import com.android.wildex.model.user.UserFriendsRepository
 import com.android.wildex.model.user.UserRepository
 import com.android.wildex.model.user.UserSettingsRepository
+import com.android.wildex.model.user.UserTokensRepository
 import com.android.wildex.model.user.UserType
 import com.android.wildex.usecase.user.DeleteUserUseCase
 import com.android.wildex.utils.MainDispatcherRule
@@ -38,6 +39,7 @@ class SettingsScreenViewModelTest {
   private lateinit var userAnimalsRepository: UserAnimalsRepository
   private lateinit var userAchievementsRepository: UserAchievementsRepository
   private lateinit var userFriendsRepository: UserFriendsRepository
+  private lateinit var userTokensRepository: UserTokensRepository
   private lateinit var friendRequestRepository: FriendRequestRepository
   private lateinit var postsRepository: PostsRepository
   private lateinit var reportRepository: ReportRepository
@@ -81,6 +83,7 @@ class SettingsScreenViewModelTest {
     userAnimalsRepository = mockk()
     userAchievementsRepository = mockk()
     userFriendsRepository = mockk()
+    userTokensRepository = mockk()
     friendRequestRepository = mockk()
     postsRepository = mockk()
     reportRepository = mockk()
@@ -93,6 +96,7 @@ class SettingsScreenViewModelTest {
             authRepository = authRepository,
             userSettingsRepository = userSettingsRepository,
             userRepository = userRepository,
+            userTokensRepository = userTokensRepository,
             currentUserId = "currentUserId",
             deleteUserUseCase =
                 DeleteUserUseCase(
@@ -107,7 +111,7 @@ class SettingsScreenViewModelTest {
                     likeRepository,
                     commentRepository,
                     authRepository,
-                ),
+                    userTokensRepository),
         )
 
     coEvery { userRepository.getUser("currentUserId") } returns u1

--- a/app/src/test/java/com/android/wildex/usecase/user/DeleteUserUseCaseTest.kt
+++ b/app/src/test/java/com/android/wildex/usecase/user/DeleteUserUseCaseTest.kt
@@ -11,6 +11,7 @@ import com.android.wildex.model.user.UserAnimalsRepository
 import com.android.wildex.model.user.UserFriendsRepository
 import com.android.wildex.model.user.UserRepository
 import com.android.wildex.model.user.UserSettingsRepository
+import com.android.wildex.model.user.UserTokensRepository
 import com.android.wildex.utils.MainDispatcherRule
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -31,6 +32,7 @@ class DeleteUserUseCaseTest {
   private lateinit var userAnimalsRepository: UserAnimalsRepository
   private lateinit var userAchievementsRepository: UserAchievementsRepository
   private lateinit var userFriendsRepository: UserFriendsRepository
+  private lateinit var userTokensRepository: UserTokensRepository
   private lateinit var friendRequestRepository: FriendRequestRepository
   private lateinit var postsRepository: PostsRepository
   private lateinit var reportRepository: ReportRepository
@@ -48,6 +50,7 @@ class DeleteUserUseCaseTest {
     userAnimalsRepository = mockk()
     userAchievementsRepository = mockk()
     userFriendsRepository = mockk()
+    userTokensRepository = mockk()
     friendRequestRepository = mockk()
     postsRepository = mockk()
     reportRepository = mockk()
@@ -68,6 +71,7 @@ class DeleteUserUseCaseTest {
             likeRepository,
             commentRepository,
             authRepository,
+            userTokensRepository,
         )
   }
 
@@ -87,6 +91,7 @@ class DeleteUserUseCaseTest {
           RuntimeException("bim-boom")
       coEvery { friendRequestRepository.deleteAllFriendRequestsOfUser(userId) } throws
           RuntimeException("bim-boom")
+      coEvery { userTokensRepository.deleteUserTokens(userId) } throws RuntimeException("bim-boom")
 
       try {
         useCase(userId)
@@ -114,6 +119,7 @@ class DeleteUserUseCaseTest {
       coEvery { reportRepository.deleteReportsByUser(userId) } just Runs
       coEvery { likeRepository.deleteLikesByUser(userId) } just Runs
       coEvery { commentRepository.deleteCommentsByUser(userId) } just Runs
+      coEvery { userTokensRepository.deleteUserTokens(userId) } just Runs
       coEvery { authRepository.deleteUserAuth() } returns Result.success(Unit)
 
       try {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ firebaseAuthKtx = "23.0.0"
 firebaseDatabaseKtx = "21.0.0"
 firebaseFirestore = "25.1.0"
 firebaseStorage = "21.0.1"
+firebaseMessaging = "24.1.0"
 
 # Credential manager
 credentials = "1.3.0"
@@ -95,6 +96,7 @@ firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx", version.
 firebase-database-ktx = { module = "com.google.firebase:firebase-database-ktx", version.ref = "firebaseDatabaseKtx" }
 firebase-firestore = { module = "com.google.firebase:firebase-firestore", version.ref = "firebaseFirestore" }
 firebase-storage = { module = "com.google.firebase:firebase-storage-ktx", version.ref = "firebaseStorage" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "firebaseMessaging" }
 
 kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", version.ref = "kaspresso" }
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }


### PR DESCRIPTION
## Description
This PR's purpose is to add a `userTokens` repository for storing user tokens in preparation for the notification implementation. The main changes are :
- The FCM (Firebase Cloud Messaging) service's dependency was added.
- Implementation of a `userTokens` repository to store each user's tokens.
- Add repository calls to the sign in and settings screens' view models for adding/deleting current app instance's token on login/logout,  as well as the `InitializeUserUseCase` and `DeleteUserUseCase` for initializing/deleting the `UserTokens` object in the database when creating/deleting an account. 
- Note that the notifications' logo is not correctly shown and the navigation onClick is not yet implemented, as these are for [PR 337](https://github.com/wildex-swent/wildex-app/pull/337).
## Related issues
Closes #308 

## Trade-offs and known limitations
Every user has to be created once again for the changes to take place. For now, notifications only appear when the app is not currently active. You are welcome to discuss the possibility of other implementations here.

## How to test
It is possible to test this if you can get 2 android devices with the app (one of them can also be the android studio emulator), since the server code is already deployed. Therefore, you can for example post something with one account and have the other account like the post. A notification will be shown on the poster's device.
