### PR TITLE
feat: improve notification screen and add extra functionnalities

### DIFF
--- a/app/src/androidTest/java/com/android/wildex/model/notification/NotificationRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/model/notification/NotificationRepositoryFirestoreTest.kt
@@ -23,7 +23,7 @@ class NotificationRepositoryFirestoreTest : FirestoreTest(NOTIFICATION_COLLECTIO
           notificationId = "notification1",
           targetId = "target1",
           authorId = "author1",
-          isRead = false,
+          read = false,
           title = "title1",
           body = "body1",
           route = "route1",
@@ -35,7 +35,7 @@ class NotificationRepositoryFirestoreTest : FirestoreTest(NOTIFICATION_COLLECTIO
           notificationId = "notification2",
           targetId = "target2",
           authorId = "author2",
-          isRead = false,
+          read = false,
           title = "title2",
           body = "body2",
           route = "route2",
@@ -47,7 +47,7 @@ class NotificationRepositoryFirestoreTest : FirestoreTest(NOTIFICATION_COLLECTIO
           notificationId = "notification3",
           targetId = "target1",
           authorId = "author3",
-          isRead = true,
+          read = true,
           title = "title3",
           body = "body3",
           route = "route3",
@@ -202,7 +202,7 @@ class NotificationRepositoryFirestoreTest : FirestoreTest(NOTIFICATION_COLLECTIO
             .await()
             .toNotification()
 
-    assert(updatedNotification.isRead)
+    assert(updatedNotification.read)
   }
 
   @Test(expected = IllegalArgumentException::class)
@@ -235,9 +235,9 @@ class NotificationRepositoryFirestoreTest : FirestoreTest(NOTIFICATION_COLLECTIO
             .await()
             .toNotification()
 
-    assertTrue(updatedNotification1.isRead)
-    assertFalse(updatedNotification2.isRead)
-    assertTrue(updatedNotification3.isRead)
+    assertTrue(updatedNotification1.read)
+    assertFalse(updatedNotification2.read)
+    assertTrue(updatedNotification3.read)
   }
 
   @Test

--- a/app/src/main/java/com/android/wildex/MainActivity.kt
+++ b/app/src/main/java/com/android/wildex/MainActivity.kt
@@ -54,6 +54,7 @@ import com.android.wildex.ui.navigation.BottomNavigationMenu
 import com.android.wildex.ui.navigation.NavigationActions
 import com.android.wildex.ui.navigation.Screen
 import com.android.wildex.ui.navigation.Tab
+import com.android.wildex.ui.notification.NotificationScreen
 import com.android.wildex.ui.post.PostDetailsScreen
 import com.android.wildex.ui.profile.EditProfileScreen
 import com.android.wildex.ui.profile.ProfileScreen
@@ -197,6 +198,19 @@ fun WildexApp(
 
     // Location Picker
     locationPickerComposable(navigationActions, navController)
+
+    // Notifications
+    notificationsComposable(navigationActions)
+  }
+}
+
+private fun NavGraphBuilder.notificationsComposable(navigationActions: NavigationActions) {
+  composable(Screen.Notifications.route) {
+    NotificationScreen(
+        onGoBack = { navigationActions.goBack() },
+        onProfileClick = { navigationActions.navigateTo(Screen.Profile(it)) },
+        onNotificationClick = { navigationActions.navigateTo(Screen.fromString(it)) },
+    )
   }
 }
 
@@ -442,6 +456,7 @@ private fun NavGraphBuilder.homeComposable(
         },
         onPostClick = { navigationActions.navigateTo(Screen.PostDetails(it)) },
         onProfilePictureClick = { navigationActions.navigateTo(Screen.Profile(it)) },
+        onNotificationClick = { navigationActions.navigateTo(Screen.Notifications) },
     )
   }
 }

--- a/app/src/main/java/com/android/wildex/model/notification/Notification.kt
+++ b/app/src/main/java/com/android/wildex/model/notification/Notification.kt
@@ -8,7 +8,7 @@ data class Notification(
     val notificationId: Id,
     val targetId: Id,
     val authorId: Id,
-    val isRead: Boolean,
+    val read: Boolean,
     val title: String,
     val body: String,
     val route: String,

--- a/app/src/main/java/com/android/wildex/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/wildex/ui/navigation/NavigationActions.kt
@@ -83,6 +83,8 @@ sealed class Screen(
     }
   }
 
+  object Notifications : Screen(route = "notifications", name = "Notifications")
+
   companion object {
     fun fromString(path: String): Screen {
       val pathParts = path.split("/")
@@ -102,6 +104,7 @@ sealed class Screen(
         "friend_screen" -> Social(pathParts[1])
         "achievement_screen" -> Achievements(pathParts[1])
         "animal_information_screen" -> AnimalInformation(pathParts[1])
+        "notifications" -> Notifications
         else -> Auth
       }
     }

--- a/app/src/main/java/com/android/wildex/ui/notification/NotificationTopBar.kt
+++ b/app/src/main/java/com/android/wildex/ui/notification/NotificationTopBar.kt
@@ -1,8 +1,5 @@
 package com.android.wildex.ui.notification
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -13,30 +10,27 @@ import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import com.android.wildex.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NotificationTopBar(onGoBack: () -> Unit, goBackTag: String) {
+fun NotificationTopBar(onGoBack: () -> Unit) {
   val cs = colorScheme
   CenterAlignedTopAppBar(
       title = {
-        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-          Text(
-              text = LocalContext.current.getString(R.string.notification_title),
-              style = typography.titleLarge,
-              color = cs.onBackground,
-          )
-        }
+        Text(
+            text = stringResource(R.string.notifications_title),
+            style = typography.titleLarge,
+            color = cs.onBackground,
+            modifier = Modifier.testTag(NotificationScreenTestTags.TOP_BAR_TITLE),
+        )
       },
       navigationIcon = {
         IconButton(
-            modifier = Modifier.testTag(goBackTag),
+            modifier = Modifier.testTag(NotificationScreenTestTags.BACK_BUTTON),
             onClick = { onGoBack() },
         ) {
           Icon(
@@ -46,8 +40,6 @@ fun NotificationTopBar(onGoBack: () -> Unit, goBackTag: String) {
           )
         }
       },
-      actions = {
-        // Empty box to center the title
-        Box(modifier = Modifier.size(48.dp))
-      })
+      modifier = Modifier.testTag(NotificationScreenTestTags.TOP_BAR),
+  )
 }

--- a/app/src/main/java/com/android/wildex/ui/notification/NotificationsUtils.kt
+++ b/app/src/main/java/com/android/wildex/ui/notification/NotificationsUtils.kt
@@ -1,0 +1,144 @@
+package com.android.wildex.ui.notification
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.android.wildex.R
+import kotlinx.coroutines.delay
+
+@Composable
+fun ActionsRow(onMarkAllRead: () -> Unit, onDeleteAll: () -> Unit) {
+
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    // Mark all read
+    FilledTonalButton(
+        onClick = onMarkAllRead,
+        colors =
+            ButtonDefaults.filledTonalButtonColors(
+                containerColor = colorScheme.primary.copy(alpha = 0.1f),
+                contentColor = colorScheme.primary,
+            ),
+        modifier = Modifier.weight(1f).testTag(NotificationScreenTestTags.MARK_ALL_AS_READ_BUTTON),
+        shape = RoundedCornerShape(8.dp),
+    ) {
+      Icon(Icons.Default.Done, contentDescription = null)
+      Spacer(Modifier.width(6.dp))
+      Text(stringResource(R.string.notifications_mark_all_read))
+    }
+
+    // Delete all
+    FilledTonalButton(
+        onClick = onDeleteAll,
+        colors =
+            ButtonDefaults.filledTonalButtonColors(
+                containerColor = colorScheme.error.copy(alpha = 0.1f),
+                contentColor = colorScheme.error,
+            ),
+        modifier = Modifier.weight(1f).testTag(NotificationScreenTestTags.CLEAR_ALL_BUTTON),
+        shape = RoundedCornerShape(8.dp),
+    ) {
+      Icon(Icons.Default.Delete, contentDescription = null)
+      Spacer(Modifier.width(6.dp))
+      Text(stringResource(R.string.notifications_delete_all))
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SwipeToDeleteNotification(
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+    animationDuration: Int = 500,
+    content: @Composable RowScope.() -> Unit = {},
+) {
+  var isDeleting by remember { mutableStateOf(false) }
+
+  val dismissState = rememberSwipeToDismissBoxState(initialValue = SwipeToDismissBoxValue.Settled)
+
+  LaunchedEffect(dismissState.currentValue) {
+    if (dismissState.currentValue == SwipeToDismissBoxValue.StartToEnd) {
+      isDeleting = true
+      delay(animationDuration.toLong())
+      onDelete()
+    }
+  }
+
+  AnimatedVisibility(
+      visible = !isDeleting,
+      exit =
+          slideOutHorizontally(
+              targetOffsetX = { fullWidth -> fullWidth },
+              animationSpec = tween(durationMillis = animationDuration),
+          ) + fadeOut(animationSpec = tween(durationMillis = animationDuration)),
+      modifier = modifier,
+  ) {
+    SwipeToDismissBox(
+        state = dismissState,
+        enableDismissFromStartToEnd = true,
+        enableDismissFromEndToStart = false,
+        backgroundContent = {
+          val backgroundColor = colorScheme.background
+          val errorColor = colorScheme.error
+
+          val progress = dismissState.progress
+          val animatedColor = lerp(errorColor, backgroundColor, progress)
+
+          Box(
+              modifier =
+                  Modifier.fillMaxSize().background(animatedColor).padding(horizontal = 20.dp),
+              contentAlignment = Alignment.CenterStart,
+          ) {
+            Icon(
+                imageVector = Icons.Default.Delete,
+                contentDescription = "Delete",
+                tint = colorScheme.onError,
+                modifier = Modifier.size(24.dp).alpha(progress),
+            )
+          }
+        },
+        content = content,
+    )
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,8 +72,10 @@
     <string name="no_nearby_posts">No nearby posts.\nStart posting…</string>
 
     <!-- Notification screen -->
-    <string name="notification_title">Notifications</string>
-    <string name="no_notifications">No notifications yet.</string>
+    <string name="notifications_title">Notifications</string>
+    <string name="notifications_no_notifications">No notifications yet.</string>
+    <string name="notifications_delete_all">Delete all</string>
+    <string name="notifications_mark_all_read">Mark all read</string>
 
     <!-- Map screen -->
     <string name="map_style">mapbox://styles/ainar5724/cmh7gfj6g00eo01qxdj3ca7tq</string>

--- a/app/src/test/java/com/android/wildex/dataClasses/DataClassesTest.kt
+++ b/app/src/test/java/com/android/wildex/dataClasses/DataClassesTest.kt
@@ -228,7 +228,7 @@ class DataClassesTest {
             notificationId = "notification1",
             targetId = "user1",
             authorId = "user2",
-            isRead = false,
+            read = false,
             title = "New Friend Request",
             body = "John Doe has sent you a friend request.",
             route = "route",
@@ -238,7 +238,7 @@ class DataClassesTest {
     TestCase.assertEquals("notification1", notification.notificationId)
     TestCase.assertEquals("user1", notification.targetId)
     TestCase.assertEquals("user2", notification.authorId)
-    TestCase.assertEquals(false, notification.isRead)
+    TestCase.assertEquals(false, notification.read)
     TestCase.assertEquals("New Friend Request", notification.title)
     TestCase.assertEquals("John Doe has sent you a friend request.", notification.body)
     TestCase.assertEquals("route", notification.route)

--- a/app/src/test/java/com/android/wildex/ui/notification/NotificationScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/notification/NotificationScreenViewModelTest.kt
@@ -7,15 +7,18 @@ import com.android.wildex.model.user.UserRepository
 import com.android.wildex.model.user.UserType
 import com.android.wildex.utils.MainDispatcherRule
 import com.google.firebase.Timestamp
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
+import io.mockk.just
 import io.mockk.mockk
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -43,7 +46,7 @@ class NotificationScreenViewModelTest {
           notificationId = "n1",
           targetId = "t1",
           authorId = sampleAuthor.userId,
-          isRead = false,
+          read = false,
           title = "Titre test",
           body = "Corps test",
           route = "route/test",
@@ -65,11 +68,11 @@ class NotificationScreenViewModelTest {
   @Test
   fun initial_UI_state_defaults() {
     val s = viewModel.uiState.value
-    Assert.assertTrue(s.notifications.isEmpty())
-    Assert.assertFalse(s.isLoading)
-    Assert.assertFalse(s.isRefreshing)
-    Assert.assertFalse(s.isError)
-    Assert.assertNull(s.errorMsg)
+    assertTrue(s.notifications.isEmpty())
+    assertFalse(s.isLoading)
+    assertFalse(s.isRefreshing)
+    assertFalse(s.isError)
+    assertNull(s.errorMsg)
   }
 
   @Test
@@ -83,15 +86,15 @@ class NotificationScreenViewModelTest {
         advanceUntilIdle()
 
         val s = viewModel.uiState.value
-        Assert.assertFalse(s.isLoading)
-        Assert.assertFalse(s.isError)
-        Assert.assertNull(s.errorMsg)
-        Assert.assertEquals(1, s.notifications.size)
+        assertFalse(s.isLoading)
+        assertFalse(s.isError)
+        assertNull(s.errorMsg)
+        assertEquals(1, s.notifications.size)
         val ui = s.notifications.first()
-        Assert.assertEquals(sampleNotification.notificationId, ui.notificationId)
-        Assert.assertEquals(sampleNotification.title, ui.notificationTitle)
-        Assert.assertEquals(sampleNotification.body, ui.notificationDescription)
-        Assert.assertEquals(sampleAuthor.username, ui.simpleUser.username)
+        assertEquals(sampleNotification.notificationId, ui.notificationId)
+        assertEquals(sampleNotification.title, ui.notificationTitle)
+        assertEquals(sampleNotification.body, ui.notificationDescription)
+        assertEquals(sampleAuthor.username, ui.author.username)
 
         coVerify(exactly = 1) { notificationRepository.getAllNotificationsForUser("uid-1") }
         coVerify(exactly = 1) { userRepository.getSimpleUser(sampleAuthor.userId) }
@@ -108,10 +111,10 @@ class NotificationScreenViewModelTest {
         advanceUntilIdle()
 
         val s = viewModel.uiState.value
-        Assert.assertTrue(s.isError)
-        Assert.assertFalse(s.isLoading)
-        Assert.assertNotNull(s.errorMsg)
-        Assert.assertTrue(s.errorMsg!!.contains("Error loading notifications: boom"))
+        assertTrue(s.isError)
+        assertFalse(s.isLoading)
+        assertNotNull(s.errorMsg)
+        assertTrue(s.errorMsg!!.contains("Error loading notifications: boom"))
         coVerify(exactly = 1) { notificationRepository.getAllNotificationsForUser("uid-1") }
         confirmVerified(notificationRepository, userRepository)
       }
@@ -127,7 +130,7 @@ class NotificationScreenViewModelTest {
         advanceUntilIdle()
 
         val s = viewModel.uiState.value
-        Assert.assertEquals(1, s.notifications.size)
+        assertEquals(1, s.notifications.size)
         coVerify(exactly = 1) { notificationRepository.getAllNotificationsForUser("uid-1") }
         coVerify(exactly = 1) { userRepository.getSimpleUser(sampleAuthor.userId) }
         confirmVerified(notificationRepository, userRepository)
@@ -143,6 +146,287 @@ class NotificationScreenViewModelTest {
       assertNotNull(after.errorMsg)
       assertTrue(
           after.errorMsg!!.contains("You are currently offline\nYou can not refresh for now :/"))
+      viewModel.clearErrorMsg()
+      assertNull(viewModel.uiState.value.errorMsg)
     }
   }
+
+  @Test
+  fun markAllAsRead_updatesState() =
+      mainDispatcherRule.runTest {
+        coEvery { notificationRepository.markAllNotificationsForUserAsRead("uid-1") } just Runs
+        coEvery { notificationRepository.getAllNotificationsForUser("uid-1") } returns
+            listOf(sampleNotification.copy(read = true))
+        coEvery { userRepository.getSimpleUser(sampleAuthor.userId) } returns sampleAuthor
+
+        viewModel.markAllAsRead()
+        advanceUntilIdle()
+
+        val s = viewModel.uiState.value
+        assertFalse(s.isLoading)
+        assertFalse(s.isError)
+        assertNull(s.errorMsg)
+        assertTrue(s.notifications.first().notificationReadState)
+
+        coVerify(exactly = 1) { notificationRepository.markAllNotificationsForUserAsRead("uid-1") }
+        coVerify(exactly = 1) { notificationRepository.getAllNotificationsForUser("uid-1") }
+        coVerify(exactly = 1) { userRepository.getSimpleUser(sampleAuthor.userId) }
+        confirmVerified(notificationRepository, userRepository)
+      }
+
+  @Test
+  fun markAllAsRead_error_setsError() =
+      mainDispatcherRule.runTest {
+        coEvery { notificationRepository.markAllNotificationsForUserAsRead("uid-1") } throws
+            RuntimeException("Failed to mark all as read")
+
+        viewModel.markAllAsRead()
+        advanceUntilIdle()
+
+        val s = viewModel.uiState.value
+        assertTrue(s.isError)
+        assertFalse(s.isLoading)
+        assertNotNull(s.errorMsg)
+        assertTrue(s.errorMsg!!.contains("Error marking all notifications as read"))
+
+        coVerify(exactly = 1) { notificationRepository.markAllNotificationsForUserAsRead("uid-1") }
+        confirmVerified(notificationRepository, userRepository)
+      }
+
+  @Test
+  fun markAsRead_updatesState() =
+      mainDispatcherRule.runTest {
+        coEvery { notificationRepository.markNotificationAsRead("n1") } just Runs
+        coEvery { notificationRepository.getAllNotificationsForUser("uid-1") } returns
+            listOf(sampleNotification.copy(read = true))
+        coEvery { userRepository.getSimpleUser(sampleAuthor.userId) } returns sampleAuthor
+
+        viewModel.markAsRead("n1")
+        advanceUntilIdle()
+
+        val s = viewModel.uiState.value
+        assertFalse(s.isLoading)
+        assertFalse(s.isError)
+        assertNull(s.errorMsg)
+        assertTrue(s.notifications.first().notificationReadState)
+
+        coVerify(exactly = 1) { notificationRepository.markNotificationAsRead("n1") }
+        coVerify(exactly = 1) { notificationRepository.getAllNotificationsForUser("uid-1") }
+        coVerify(exactly = 1) { userRepository.getSimpleUser(sampleAuthor.userId) }
+        confirmVerified(notificationRepository, userRepository)
+      }
+
+  @Test
+  fun markAsRead_error_setsError() =
+      mainDispatcherRule.runTest {
+        coEvery { notificationRepository.markNotificationAsRead("n1") } throws
+            RuntimeException("Failed to mark as read")
+
+        viewModel.markAsRead("n1")
+        advanceUntilIdle()
+
+        val s = viewModel.uiState.value
+        assertTrue(s.isError)
+        assertFalse(s.isLoading)
+        assertNotNull(s.errorMsg)
+        assertTrue(s.errorMsg!!.contains("Error marking notification as read"))
+
+        coVerify(exactly = 1) { notificationRepository.markNotificationAsRead("n1") }
+        confirmVerified(notificationRepository, userRepository)
+      }
+
+  @Test
+  fun clearNotification_success() =
+      mainDispatcherRule.runTest {
+        coEvery { notificationRepository.deleteNotification("n1") } just Runs
+        coEvery { notificationRepository.getAllNotificationsForUser("uid-1") } returns emptyList()
+
+        viewModel.clearNotification("n1")
+        advanceUntilIdle()
+
+        val s = viewModel.uiState.value
+        assertFalse(s.isLoading)
+        assertFalse(s.isError)
+        assertNull(s.errorMsg)
+        assertTrue(s.notifications.isEmpty())
+
+        coVerify(exactly = 1) { notificationRepository.deleteNotification("n1") }
+        coVerify(exactly = 1) { notificationRepository.getAllNotificationsForUser("uid-1") }
+        confirmVerified(notificationRepository, userRepository)
+      }
+
+  @Test
+  fun clearNotification_error_setsError() =
+      mainDispatcherRule.runTest {
+        coEvery { notificationRepository.deleteNotification("n1") } throws
+            RuntimeException("Failed to delete")
+
+        viewModel.clearNotification("n1")
+        advanceUntilIdle()
+
+        val s = viewModel.uiState.value
+        assertTrue(s.isError)
+        assertFalse(s.isLoading)
+        assertNotNull(s.errorMsg)
+        assertTrue(s.errorMsg!!.contains("Error clearing notification"))
+
+        coVerify(exactly = 1) { notificationRepository.deleteNotification("n1") }
+        confirmVerified(notificationRepository, userRepository)
+      }
+
+  @Test
+  fun clearAllNotifications_success() =
+      mainDispatcherRule.runTest {
+        coEvery { notificationRepository.deleteAllNotificationsForUser("uid-1") } just Runs
+        coEvery { notificationRepository.getAllNotificationsForUser("uid-1") } returns emptyList()
+
+        viewModel.clearAllNotifications()
+        advanceUntilIdle()
+
+        val s = viewModel.uiState.value
+        assertFalse(s.isLoading)
+        assertFalse(s.isError)
+        assertNull(s.errorMsg)
+        assertTrue(s.notifications.isEmpty())
+
+        coVerify(exactly = 1) { notificationRepository.deleteAllNotificationsForUser("uid-1") }
+        coVerify(exactly = 1) { notificationRepository.getAllNotificationsForUser("uid-1") }
+        confirmVerified(notificationRepository, userRepository)
+      }
+
+  @Test
+  fun clearAllNotifications_error_setsError() =
+      mainDispatcherRule.runTest {
+        coEvery { notificationRepository.deleteAllNotificationsForUser("uid-1") } throws
+            RuntimeException("Failed to delete all")
+
+        viewModel.clearAllNotifications()
+        advanceUntilIdle()
+
+        val s = viewModel.uiState.value
+        assertTrue(s.isError)
+        assertFalse(s.isLoading)
+        assertNotNull(s.errorMsg)
+        assertTrue(s.errorMsg!!.contains("Error clearing all notifications"))
+
+        coVerify(exactly = 1) { notificationRepository.deleteAllNotificationsForUser("uid-1") }
+        confirmVerified(notificationRepository, userRepository)
+      }
+
+  @Test
+  fun fetchNotifications_filtersOutFailedUserFetch() =
+      mainDispatcherRule.runTest {
+        val notification2 = sampleNotification.copy(notificationId = "n2", authorId = "author-2")
+        coEvery { notificationRepository.getAllNotificationsForUser("uid-1") } returns
+            listOf(sampleNotification, notification2)
+        coEvery { userRepository.getSimpleUser(sampleAuthor.userId) } returns sampleAuthor
+        coEvery { userRepository.getSimpleUser("author-2") } throws
+            RuntimeException("User not found")
+
+        viewModel.loadUIState()
+        advanceUntilIdle()
+
+        val s = viewModel.uiState.value
+        assertFalse(s.isError)
+        assertEquals(1, s.notifications.size)
+        assertEquals("n1", s.notifications.first().notificationId)
+
+        coVerify(exactly = 1) { notificationRepository.getAllNotificationsForUser("uid-1") }
+        coVerify(exactly = 1) { userRepository.getSimpleUser(sampleAuthor.userId) }
+        coVerify(exactly = 1) { userRepository.getSimpleUser("author-2") }
+        confirmVerified(notificationRepository, userRepository)
+      }
+
+  @Test
+  fun notificationsSortedByDate() =
+      mainDispatcherRule.runTest {
+        val olderNotification =
+            sampleNotification.copy(
+                notificationId = "n2",
+                date = Timestamp(sampleNotification.date.seconds - 1000, 0),
+            )
+        coEvery { notificationRepository.getAllNotificationsForUser("uid-1") } returns
+            listOf(olderNotification, sampleNotification)
+        coEvery { userRepository.getSimpleUser(sampleAuthor.userId) } returns sampleAuthor
+
+        viewModel.loadUIState()
+        advanceUntilIdle()
+
+        val s = viewModel.uiState.value
+        assertEquals(2, s.notifications.size)
+        assertEquals("n1", s.notifications[0].notificationId)
+        assertEquals("n2", s.notifications[1].notificationId)
+
+        coVerify(exactly = 1) { notificationRepository.getAllNotificationsForUser("uid-1") }
+        coVerify(exactly = 2) { userRepository.getSimpleUser(sampleAuthor.userId) }
+        confirmVerified(notificationRepository, userRepository)
+      }
+
+  @Test
+  fun getRelativeTime_allTimePeriods() =
+      mainDispatcherRule.runTest {
+        val now = Timestamp.now()
+        val nowSeconds = now.seconds
+        // Create notifications for each time period
+        val secondsAgo =
+            sampleNotification.copy(notificationId = "n1", date = Timestamp(nowSeconds - 10, 0))
+        val minutesAgo =
+            sampleNotification.copy(notificationId = "n2", date = Timestamp(nowSeconds - 300, 0))
+        val hoursAgo =
+            sampleNotification.copy(notificationId = "n3", date = Timestamp(nowSeconds - 7200, 0))
+        val daysAgo =
+            sampleNotification.copy(notificationId = "n4", date = Timestamp(nowSeconds - 172800, 0))
+        val weeksAgo =
+            sampleNotification.copy(
+                notificationId = "n5",
+                date = Timestamp(nowSeconds - 1209600, 0),
+            )
+        val monthsAgo =
+            sampleNotification.copy(
+                notificationId = "n6",
+                date = Timestamp(nowSeconds - 5184000, 0),
+            )
+        val yearsAgo =
+            sampleNotification.copy(
+                notificationId = "n7",
+                date = Timestamp(nowSeconds - 63072000, 0),
+            )
+        val justNow =
+            sampleNotification.copy(
+                notificationId = "n8",
+                date = Timestamp(nowSeconds - 2, 0),
+            )
+        coEvery { notificationRepository.getAllNotificationsForUser("uid-1") } returns
+            listOf(
+                secondsAgo,
+                minutesAgo,
+                hoursAgo,
+                daysAgo,
+                weeksAgo,
+                monthsAgo,
+                yearsAgo,
+                justNow,
+            )
+        coEvery { userRepository.getSimpleUser(sampleAuthor.userId) } returns sampleAuthor
+
+        viewModel.loadUIState()
+        advanceUntilIdle()
+
+        val s = viewModel.uiState.value
+        assertFalse(s.isError)
+        assertEquals(8, s.notifications.size)
+
+        val notificationMap = s.notifications.associateBy { it.notificationId }
+        assertEquals("now", notificationMap["n8"]?.notificationRelativeTime)
+        assertTrue(notificationMap["n1"]?.notificationRelativeTime?.contains("seconds ago") == true)
+        assertTrue(notificationMap["n2"]?.notificationRelativeTime?.contains("minutes ago") == true)
+        assertTrue(notificationMap["n3"]?.notificationRelativeTime?.contains("hours ago") == true)
+        assertTrue(notificationMap["n4"]?.notificationRelativeTime?.contains("days ago") == true)
+        assertTrue(notificationMap["n5"]?.notificationRelativeTime?.contains("weeks ago") == true)
+        assertTrue(notificationMap["n6"]?.notificationRelativeTime?.contains("months ago") == true)
+        assertTrue(notificationMap["n7"]?.notificationRelativeTime?.contains("years ago") == true)
+        coVerify(exactly = 1) { notificationRepository.getAllNotificationsForUser("uid-1") }
+        coVerify(exactly = 8) { userRepository.getSimpleUser(sampleAuthor.userId) }
+        confirmVerified(notificationRepository, userRepository)
+      }
 }


### PR DESCRIPTION
## Description
This PR's goal is to improve the UI of the notification screen as well as add more functionalities and ease of use. Main changes include :
- Adding a `Mark all as read` button for setting all notifications' states to read.
- Adding a `Clear all` button for deleting all notifications.
- Added relative time test for each notification.
- Adding a dot shaped indicator on the notification for the user to know that it's not read yet.
- Added Swipe gesture functionality to individual notification to delete them
- Adapted and added tests for all of the above.
- Added notifications screen navigation in the app's navigation host.
<img width="412" height="882" alt="image" src="https://github.com/user-attachments/assets/31a829fc-b3be-41b9-85ae-195b0e984abd" />

## Related issues
Closes #346 

## Trade-offs and known limitations
When deleting a notification, it takes a lot of time to update the state, which is not efficient and not good user experience.

## How to test
Simply open the app and navigate to the notification screen through the bell icon in the home screen.