### PR TITLE
fix: fix collection and settings screens UI tweak

### DIFF
--- a/app/src/main/java/com/android/wildex/ui/collection/CollectionScreen.kt
+++ b/app/src/main/java/com/android/wildex/ui/collection/CollectionScreen.kt
@@ -126,8 +126,7 @@ fun CollectionScreen(
  * Composable for the top app bar in the Collection Screen.
  *
  * @param isUserOwner Boolean indicating if the displayed collection belongs to the current user.
- * @param userProfilePictureURL URL of the user's profile picture, used when displaying the current
- *   user's collection.
+ * @param user user whose collection we are viewing
  * @param onGoBack Callback invoked when the go back button is clicked.
  * @param onProfileClick Callback invoked when the profile button is clicked.
  * @param onNotificationClick Callback invoked when the notification button is clicked.
@@ -196,7 +195,7 @@ fun AnimalsView(animalsStates: List<AnimalState>, onAnimalClick: (Id) -> Unit) {
   val screenHeight = LocalWindowInfo.current.containerSize.height.dp
   LazyColumn(modifier = Modifier.fillMaxSize().testTag(CollectionScreenTestTags.ANIMAL_LIST)) {
     val nbRows = ceil(animalsStates.size / 2.0).toInt()
-    val rowHeight = (screenHeight) / 4
+    val rowHeight = (screenHeight) / 12
     items(nbRows) { index ->
       val rowStartIndex = index * 2
       Row(
@@ -241,24 +240,26 @@ fun AnimalView(animalState: AnimalState, onAnimalClick: (Id) -> Unit, modifier: 
             AsyncImage(
                 model = animalPictureURL,
                 contentDescription = animalName,
-                modifier = Modifier.fillMaxSize().weight(0.8f),
+                modifier = Modifier.fillMaxSize().weight(0.82f),
                 contentScale = ContentScale.Crop)
-
-            Text(
-                text = if (animalState.isUnlocked) animalName else "???",
-                color = colorScheme.background,
-                textAlign = TextAlign.Center,
-                style = typography.titleMedium,
+            Box(
                 modifier =
-                    Modifier.fillMaxWidth().weight(0.2f).background(color = colorScheme.primary),
-            )
+                    Modifier.fillMaxWidth().weight(0.18f).background(color = colorScheme.primary),
+                contentAlignment = Alignment.Center) {
+                  Text(
+                      text = if (animalState.isUnlocked) animalName else "???",
+                      color = colorScheme.background,
+                      textAlign = TextAlign.Center,
+                      style = typography.titleMedium,
+                      modifier = Modifier.fillMaxWidth())
+                }
           }
         }
     if (!animalState.isUnlocked) {
       Box(
           modifier =
               Modifier.matchParentSize()
-                  .background(color = colorScheme.onBackground.copy(alpha = 0.4f)),
+                  .background(color = colorScheme.background.copy(alpha = 0.4f)),
           contentAlignment = Alignment.Center) {
             Image(
                 painter = painterResource(id = R.drawable.lock),

--- a/app/src/main/java/com/android/wildex/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/wildex/ui/settings/SettingsScreen.kt
@@ -142,7 +142,7 @@ fun SettingsScreen(
               elevation = FloatingActionButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp),
               modifier =
                   Modifier.padding(bottom = 16.dp)
-                      .padding(horizontal = screenWidth / 25)
+                      .padding(horizontal = screenWidth / 40)
                       .fillMaxWidth()
                       .border(2.dp, colorScheme.primary, RoundedCornerShape(16.dp))
                       .height(55.dp)
@@ -162,7 +162,7 @@ fun SettingsScreen(
               elevation = FloatingActionButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp),
               modifier =
                   Modifier.padding(bottom = 16.dp)
-                      .padding(horizontal = screenWidth / 25)
+                      .padding(horizontal = screenWidth / 40)
                       .fillMaxWidth()
                       .border(2.dp, colorScheme.primary, RoundedCornerShape(16.dp))
                       .height(55.dp)
@@ -276,8 +276,8 @@ fun SettingsContent(
       )
 
   LazyColumn(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
-    val settingHeight = screenHeight / 12
-    val paddingHorizontal = screenWidth / 25
+    val settingHeight = screenHeight / 34
+    val paddingHorizontal = screenWidth / 55
     item {
       EditProfileOption(paddingHorizontal, settingHeight, onEditProfileClick)
       SettingsDivider()
@@ -566,7 +566,7 @@ fun UserStatusOption(
       icon = Icons.Outlined.Person,
       settingName = LocalContext.current.getString(R.string.user_status),
   ) {
-    SingleChoiceSegmentedButtonRow(modifier = Modifier.width(screenWidth.div(1.9f))) {
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.width(screenWidth.div(5))) {
       options.forEachIndexed { index, option ->
         SegmentedButton(
             shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
@@ -633,7 +633,7 @@ fun AppearanceModeOption(
     val checkedIcons = listOf(Icons.Filled.Autorenew, Icons.Filled.LightMode, Icons.Filled.DarkMode)
     val selectedIndex = AppearanceMode.entries.indexOf(currentAppearanceMode)
 
-    SingleChoiceSegmentedButtonRow(modifier = Modifier.width(screenWidth.div(1.8f))) {
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.width(screenWidth.div(4.6f))) {
       options.forEachIndexed { index, option ->
         SegmentedButton(
             shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),


### PR DESCRIPTION
- Fixed a UI tweak in the Collection and Settings screens, introduced by mistake after the #311 PR due to replacing `LocalConfiguration.current.screenHeight` by `LocalWindowInfo.current.containerSize.height`
- While I was at it, I changed the veil color in the collection screen to be the same as the background's color.
- I also centered the animals' names in the text box in the Collection screen.