### PR TITLE
feat: Add Filters to posts

### DIFF
--- a/app/src/androidTest/java/com/android/wildex/ui/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/android/wildex/ui/home/HomeScreenTest.kt
@@ -43,6 +43,7 @@ class HomeScreenTest {
   private val commentRepository = LocalRepositories.commentRepository
   private val animalRepository = LocalRepositories.animalRepository
   private val userSettingsRepository = LocalRepositories.userSettingsRepository
+  private val userFriendsRepository = LocalRepositories.userFriendsRepository
 
   private val fullPost =
       Post(
@@ -68,6 +69,7 @@ class HomeScreenTest {
             commentRepository,
             animalRepository,
             userSettingsRepository,
+            userFriendsRepository,
             "currentUserId-1",
         )
     userRepository.addUser(
@@ -450,6 +452,7 @@ class HomeScreenTest {
               LocalRepositories.commentRepository,
               LocalRepositories.animalRepository,
               LocalRepositories.userSettingsRepository,
+              LocalRepositories.userFriendsRepository,
               "currentUserId-1",
           )
       vm.loadUIState()

--- a/app/src/main/java/com/android/wildex/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/android/wildex/ui/home/HomeScreen.kt
@@ -142,13 +142,16 @@ fun HomeScreen(
         uiState.isError -> LoadingFail()
         uiState.isLoading -> LoadingScreen()
         postStates.isEmpty() -> NoPostsView()
-        else ->
-            PostsView(
-                postStates = postStates,
-                onProfilePictureClick = onProfilePictureClick,
-                onPostLike = homeScreenViewModel::toggleLike,
-                onPostClick = onPostClick,
-            )
+        else -> {
+          val filteredPostStates = homeScreenViewModel.filterPosts(postStates = postStates)
+
+          PostsView(
+              postStates = filteredPostStates,
+              onProfilePictureClick = onProfilePictureClick,
+              onPostLike = homeScreenViewModel::toggleLike,
+              onPostClick = onPostClick,
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
This PR introduces a post-filtering system that allows users to choose which posts will be displayed on their homepage. Regardless of which filters are applied, posts are always sorted from most to least recent.

There exist four filters, which can be combined freely:
- Display only posts from the user's friends
- Display only posts related to a specific animal
- Display only posts from a given location
- Display only posts from a specific author

About the tests:
- Added new tests in `HomeScreenViewModelTest.kt`
- Updated `HomeScreenTest.kt` so it handles the new parameter introduced in the HomeScreen function

## Related issues
Closes #317 

## Trade-offs or known limitations 
Although the filtering logic works, the filters are constants for now, you can only change them by directly modifying the code. The HomeScreen UI still needs to be updated to allow users to interact with those filters to freely add/remove them. This will be addressed in a separate PR.