### PR TITLE
feat: location picker integration

### DIFF
--- a/app/src/main/java/com/android/wildex/MainActivity.kt
+++ b/app/src/main/java/com/android/wildex/MainActivity.kt
@@ -411,12 +411,21 @@ private fun NavGraphBuilder.cameraComposable(
     navigationActions: NavigationActions,
     currentUserId: Id?,
 ) {
-  composable(Screen.Camera.route) {
+
+  composable(Screen.Camera.route) { backStackEntry ->
+    val savedStateHandle = backStackEntry.savedStateHandle
+    val serializedLocationFlow = remember {
+      savedStateHandle.getStateFlow<Location?>(LOCATION_PICKER_RESULT_KEY, null)
+    }
+    val pickedLocation by serializedLocationFlow.collectAsStateWithLifecycle()
     CameraScreen(
         bottomBar = {
           if (currentUserId != null) BottomNavigation(Tab.Camera, navigationActions, currentUserId)
         },
         onPost = { navigationActions.navigateTo(Screen.Home) },
+        onPickLocation = { navigationActions.navigateTo(Screen.LocationPicker) },
+        serializedLocation = pickedLocation,
+        onPickedLocationConsumed = { savedStateHandle[LOCATION_PICKER_RESULT_KEY] = null },
     )
   }
 }

--- a/app/src/main/java/com/android/wildex/ui/camera/CameraScreenViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/camera/CameraScreenViewModel.kt
@@ -13,13 +13,12 @@ import com.android.wildex.model.animal.Animal
 import com.android.wildex.model.animal.AnimalRepository
 import com.android.wildex.model.animaldetector.AnimalDetectResponse
 import com.android.wildex.model.animaldetector.AnimalInfoRepository
-import com.android.wildex.model.location.GeocodingRepository
 import com.android.wildex.model.social.Post
 import com.android.wildex.model.social.PostsRepository
 import com.android.wildex.model.storage.StorageRepository
 import com.android.wildex.model.user.UserAnimalsRepository
 import com.android.wildex.model.utils.Id
-import com.google.android.gms.location.LocationServices
+import com.android.wildex.model.utils.Location
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
@@ -27,16 +26,16 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 
 data class CameraUiState(
     val animalDetectResponse: AnimalDetectResponse? = null,
     val currentImageUri: Uri? = null,
     val description: String = "",
-    val addLocation: Boolean = false,
     val errorMsg: String? = null,
     val isLoading: Boolean = false,
     val isDetecting: Boolean = false,
+    val location: Location? = null,
+    val hasPickedLocation: Boolean = false,
     val isSavingOffline: Boolean = false,
 )
 
@@ -48,18 +47,22 @@ class CameraScreenViewModel(
     private val animalRepository: AnimalRepository = RepositoryProvider.animalRepository,
     private val animalInfoRepository: AnimalInfoRepository =
         RepositoryProvider.animalInfoRepository,
-    private val geocodingRepository: GeocodingRepository = RepositoryProvider.geocodingRepository,
     private val currentUserId: Id? = Firebase.auth.uid,
 ) : ViewModel() {
   private val _uiState = MutableStateFlow(CameraUiState())
   val uiState: StateFlow<CameraUiState> = _uiState.asStateFlow()
 
-  /* resets to default state where camera preview is shown */
+  /** resets to default state where camera preview is shown */
   fun resetState() {
     _uiState.value = CameraUiState()
   }
 
-  /* detects animal in the image */
+  /**
+   * detects animal in the image
+   *
+   * @param imageUri The URI of the image to be analyzed for animal detection.
+   * @param context The context used for accessing content resolver and other resources.
+   */
   fun detectAnimalImage(imageUri: Uri, context: Context) {
     _uiState.value = _uiState.value.copy(isDetecting = true, currentImageUri = imageUri)
     viewModelScope.launch {
@@ -104,7 +107,8 @@ class CameraScreenViewModel(
               ContentValues().apply {
                 put(
                     MediaStore.MediaColumns.DISPLAY_NAME,
-                    "wildex_${System.currentTimeMillis()}.jpg")
+                    "wildex_${System.currentTimeMillis()}.jpg",
+                )
                 put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
                 put(MediaStore.MediaColumns.RELATIVE_PATH, "Pictures/Wildex")
               }
@@ -129,23 +133,43 @@ class CameraScreenViewModel(
     }
   }
 
-  /* updates the image uri of the post in construction, keeps it across config changes */
+  /**
+   * updates the image uri of the post in construction, keeps it across config changes
+   *
+   * @param imageUri The URI of the image to be set for the current post.
+   */
   fun updateImageUri(imageUri: Uri) {
     _uiState.value = _uiState.value.copy(currentImageUri = imageUri)
   }
 
-  /* updates the description of the post in construction, keeps it across config changes */
+  /**
+   * updates the description of the post in construction, keeps it across config changes
+   *
+   * @param description The description text to be set for the current post.
+   */
   fun updateDescription(description: String) {
     _uiState.value = _uiState.value.copy(description = description)
   }
 
-  /* toggles whether to add location to the post in construction */
-  fun toggleAddLocation() {
-    _uiState.value = _uiState.value.copy(addLocation = !_uiState.value.addLocation)
+  /**
+   * Called when the user picks a location from the LocationPickerScreen.
+   *
+   * @param picked The Location object representing the picked location.
+   */
+  fun onLocationPicked(picked: Location) {
+    _uiState.value =
+        _uiState.value.copy(
+            location = picked,
+            hasPickedLocation = true,
+        )
   }
 
-  /* calls `registerAnimal` and creates a post with the detected animal and current user,
-  with the location taken from the composable, and triggers onPost when it is posted */
+  /**
+   * calls `registerAnimal` and creates a post with the detected animal and current user, with the
+   * location taken from the composable, and triggers onPost when it is posted
+   *
+   * @param context The context used for accessing resources during post creation.
+   */
   @SuppressLint("MissingPermission")
   fun createPost(context: Context, onPost: () -> Unit) {
     val uri = uiState.value.currentImageUri ?: return
@@ -156,12 +180,7 @@ class CameraScreenViewModel(
         val postId = postsRepository.getNewPostId()
         val imageUrl = storageRepository.uploadPostImage(postId, uri)
         val animalId = response.taxonomy.id
-        val location =
-            if (_uiState.value.addLocation) {
-              LocationServices.getFusedLocationProviderClient(context).lastLocation.await().let {
-                geocodingRepository.reverseGeocode(it.latitude, it.longitude)
-              }
-            } else null
+        val location = uiState.value.location
         val finalPost =
             Post(
                 postId = postId,
@@ -188,12 +207,21 @@ class CameraScreenViewModel(
     _uiState.value = _uiState.value.copy(errorMsg = null)
   }
 
-  /** Sets a new error message in the UI state. */
+  /**
+   * Sets a new error message in the UI state.
+   *
+   * @param msg The error message to be set.
+   */
   private fun setErrorMsg(msg: String) {
     _uiState.value = _uiState.value.copy(errorMsg = msg)
   }
 
-  /* registers the animal from the animal response in the repository if not already there */
+  /**
+   * registers the animal from the animal response in the repository if not already there
+   *
+   * @param animalId The unique identifier for the animal to be registered.
+   * @param context The context used for accessing resources during animal registration.
+   */
   private suspend fun registerAnimal(animalId: Id, context: Context) {
     val detection = uiState.value.animalDetectResponse ?: return
 
@@ -210,5 +238,10 @@ class CameraScreenViewModel(
         )
     animalRepository.addAnimal(animal)
     userAnimalsRepository.addAnimalToUserAnimals(currentUserId!!, animalId)
+  }
+
+  /** Called when the user picks a location from the LocationPickerScreen. */
+  fun clearLocation() {
+    _uiState.value = _uiState.value.copy(location = null, hasPickedLocation = false)
   }
 }

--- a/app/src/main/java/com/android/wildex/ui/camera/PostCreationScreen.kt
+++ b/app/src/main/java/com/android/wildex/ui/camera/PostCreationScreen.kt
@@ -2,21 +2,18 @@ package com.android.wildex.ui.camera
 
 import android.net.Uri
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.*
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
@@ -27,6 +24,8 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.android.wildex.R
 import com.android.wildex.model.animaldetector.AnimalDetectResponse
+import com.android.wildex.model.utils.Location
+import com.android.wildex.ui.utils.location.LocationSelector
 import kotlin.math.ceil
 
 object PostCreationScreenTestTags {
@@ -36,7 +35,7 @@ object PostCreationScreenTestTags {
   const val POST_CREATION_SCREEN_SPECIES_NAME = "post_creation_screen_species_name"
   const val POST_CREATION_SCREEN_CONFIDENCE = "post_creation_screen_confidence"
   const val POST_CREATION_SCREEN_DESCRIPTION_FIELD = "post_creation_screen_description_field"
-  const val POST_CREATION_SCREEN_LOCATION_TOGGLE = "post_creation_screen_location_toggle"
+  const val POST_CREATION_SCREEN_LOCATION_PICK = "post_creation_screen_location_toggle"
   const val POST_CREATION_SCREEN_CANCEL_BUTTON = "post_creation_screen_cancel_button"
   const val POST_CREATION_SCREEN_CONFIRM_BUTTON = "post_creation_screen_confirm_button"
 }
@@ -46,13 +45,14 @@ object PostCreationScreenTestTags {
 fun PostCreationScreen(
     description: String,
     onDescriptionChange: (String) -> Unit,
-    useLocation: Boolean,
-    onLocationToggle: (Boolean) -> Unit,
     photoUri: Uri,
     detectionResponse: AnimalDetectResponse,
     onConfirm: () -> Unit,
     onCancel: () -> Unit,
+    onPickLocation: () -> Unit,
+    location: Location?,
     modifier: Modifier = Modifier,
+    onClear: () -> Unit = {},
 ) {
   val maxCharacters = 500
   val animalName = detectionResponse.animalType
@@ -197,40 +197,14 @@ fun PostCreationScreen(
                 )
               },
           )
-          // Location toggle
-          Row(
+          // Location
+          LocationSelector(
               modifier =
-                  Modifier.fillMaxWidth()
-                      .clip(RoundedCornerShape(12.dp))
-                      .clickable { onLocationToggle(!useLocation) }
-                      .testTag(PostCreationScreenTestTags.POST_CREATION_SCREEN_LOCATION_TOGGLE),
-              verticalAlignment = Alignment.CenterVertically,
-              horizontalArrangement = Arrangement.SpaceBetween,
-          ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-              Icon(
-                  imageVector = Icons.Default.LocationOn,
-                  contentDescription = null,
-                  tint = colorScheme.primary,
-              )
-              Column {
-                Text(
-                    text = stringResource(R.string.share_location),
-                    style = typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
-                )
-                Text(
-                    text = stringResource(R.string.share_location_description),
-                    style = typography.bodySmall,
-                    color = colorScheme.onSurfaceVariant,
-                )
-              }
-            }
-            Checkbox(checked = useLocation, onCheckedChange = onLocationToggle)
-          }
+                  Modifier.testTag(PostCreationScreenTestTags.POST_CREATION_SCREEN_LOCATION_PICK),
+              locationName = location?.name,
+              onClick = onPickLocation,
+              onClear = onClear,
+              fraction = 1f)
 
           // Action buttons
           Row(

--- a/app/src/main/java/com/android/wildex/ui/report/SubmitReportFormScreen.kt
+++ b/app/src/main/java/com/android/wildex/ui/report/SubmitReportFormScreen.kt
@@ -69,6 +69,7 @@ fun SubmitReportFormScreen(
     onCameraClick: () -> Unit,
     onDescriptionChange: (String) -> Unit,
     onSubmitClick: () -> Unit,
+    onClear: () -> Unit = {},
     onPickLocation: () -> Unit = {},
 ) {
   val context = LocalContext.current
@@ -82,6 +83,7 @@ fun SubmitReportFormScreen(
         uiState = uiState,
         onDescriptionChange = onDescriptionChange,
         onSubmitClick = onSubmitClick,
+        onClear = onClear,
         onPickLocation = onPickLocation,
     )
   } else {
@@ -106,6 +108,7 @@ fun SubmitReportFormScreenContent(
     uiState: SubmitReportUiState,
     onDescriptionChange: (String) -> Unit,
     onSubmitClick: () -> Unit,
+    onClear: () -> Unit = {},
     onPickLocation: () -> Unit = {},
 ) {
   Column(
@@ -182,7 +185,7 @@ fun SubmitReportFormScreenContent(
         modifier = Modifier.testTag(SubmitReportFormScreenTestTags.LOCATION_SELECTOR),
         locationName = uiState.location?.name,
         onClick = onPickLocation,
-    )
+        onClear = onClear)
 
     Spacer(modifier = Modifier.height(32.dp))
 

--- a/app/src/main/java/com/android/wildex/ui/report/SubmitReportScreen.kt
+++ b/app/src/main/java/com/android/wildex/ui/report/SubmitReportScreen.kt
@@ -156,7 +156,7 @@ fun SubmitReportScreenContent(
             onDescriptionChange = viewModel::updateDescription,
             onSubmitClick = { viewModel.submitReport(onSubmitted) },
             onPickLocation = onPickLocation,
-        )
+            onClear = { viewModel.clearLocation() })
       }
     }
   }

--- a/app/src/main/java/com/android/wildex/ui/report/SubmitReportScreenViewModel.kt
+++ b/app/src/main/java/com/android/wildex/ui/report/SubmitReportScreenViewModel.kt
@@ -51,23 +51,48 @@ class SubmitReportScreenViewModel(
   private val _uiState = MutableStateFlow(SubmitReportUiState())
   val uiState: StateFlow<SubmitReportUiState> = _uiState.asStateFlow()
 
+  /**
+   * Called when the user updates the description text.
+   *
+   * @param description The new description text.
+   */
   fun updateDescription(description: String) {
     _uiState.value = _uiState.value.copy(description = description)
   }
 
+  /**
+   * Called when the user selects or changes the image for the report.
+   *
+   * @param imageUri The URI of the selected image.
+   */
   fun updateImage(imageUri: Uri?) {
     _uiState.value = _uiState.value.copy(imageUri = imageUri)
   }
 
-  /** Called when the user picks a location from the LocationPickerScreen. */
+  /**
+   * Called when the user picks a location from the LocationPickerScreen.
+   *
+   * @param picked The location selected by the user.
+   */
   fun updateLocation(picked: Location) {
     _uiState.value = _uiState.value.copy(location = picked, hasPickedLocation = true)
   }
 
+  /** Called when the user picks a location from the LocationPickerScreen. */
+  fun clearLocation() {
+    _uiState.value = _uiState.value.copy(location = null, hasPickedLocation = false)
+  }
+
+  /** Clears any existing error message in the UI state. */
   fun clearErrorMsg() {
     _uiState.value = _uiState.value.copy(errorMsg = null)
   }
 
+  /**
+   * Submits the report with the current UI state data.
+   *
+   * @param onSuccess A callback function to be invoked upon successful submission.
+   */
   fun submitReport(onSuccess: () -> Unit) {
     val currentState = _uiState.value
 
@@ -121,10 +146,16 @@ class SubmitReportScreenViewModel(
     }
   }
 
+  /**
+   * Sets an error message in the UI state.
+   *
+   * @param message The error message to be set.
+   */
   private fun setError(message: String) {
     _uiState.value = _uiState.value.copy(errorMsg = message)
   }
 
+  /** Resets the UI state to its initial values upon successful report submission. */
   private fun resetUiStateOnSuccess() {
     _uiState.value = SubmitReportUiState()
   }

--- a/app/src/main/java/com/android/wildex/ui/utils/location/LocationSelector.kt
+++ b/app/src/main/java/com/android/wildex/ui/utils/location/LocationSelector.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -21,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -28,11 +30,13 @@ fun LocationSelector(
     modifier: Modifier = Modifier,
     locationName: String?,
     onClick: () -> Unit,
+    onClear: () -> Unit = {},
+    fraction: Float = 0.9f,
 ) {
   Box(
       modifier =
           modifier
-              .fillMaxWidth(0.9f)
+              .fillMaxWidth(fraction)
               .clickable { onClick() }
               .border(
                   width = 1.dp,
@@ -45,7 +49,7 @@ fun LocationSelector(
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxWidth(),
         ) {
-          Row(verticalAlignment = Alignment.CenterVertically) {
+          Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
             Icon(
                 imageVector = Icons.Default.LocationOn,
                 contentDescription = null,
@@ -55,11 +59,20 @@ fun LocationSelector(
             Spacer(modifier = Modifier.width(12.dp))
             Text(
                 text = locationName ?: "Select a location",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.bodyMedium,
                 color =
                     if (locationName == null) colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                     else colorScheme.onSurface,
             )
+          }
+          if (!locationName.isNullOrEmpty()) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "Clear location",
+                tint = colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+                modifier = Modifier.size(30.dp).clickable { onClear() }.padding(start = 8.dp))
           }
           Icon(
               imageVector = Icons.AutoMirrored.Filled.ArrowBack,

--- a/app/src/test/java/com/android/wildex/ui/report/SubmitReportScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/wildex/ui/report/SubmitReportScreenViewModelTest.kt
@@ -168,4 +168,15 @@ class SubmitReportScreenViewModelTest {
         assertTrue(state.errorMsg!!.contains("Network error"))
         assertFalse(state.isSubmitting)
       }
+
+  @Test
+  fun submitReport_clearsLocation() =
+      mainDispatcherRule.runTest {
+        viewModel.updateLocation(Location(46.5197, 6.6323, name = "Lausanne"))
+        assertTrue(viewModel.uiState.value.hasPickedLocation)
+        viewModel.clearLocation()
+        val state = viewModel.uiState.value
+        assertNull(state.location)
+        assertFalse(state.hasPickedLocation)
+      }
 }


### PR DESCRIPTION
## Description

This PR completes the integration of the Location Picker across the camera screen. Basically I inserted the proper location-selection logic into the post creation so everything behaves consistently and fixed the design of the location picker by adding a way to clear the location (so consequently I also had to add a new `clearLocation `method in the view models of the camera and submit report)

## What’s included

### 1. Submit Report and Camera ViewModels

I added a `clearLocation `function so that we can delete our chosen location in the `LocationSelector`.

### 2. Post Creation screen now uses the real Location Picker

I removed the old "toggle location on/off" mechanism.
Post creation now exposes a proper location selector that leads to the Location Picker, just like the submit report screen. I used the same logic as submit report.

To support that:

* the CameraScreen UI now shows a location selector instead of a toggle
* unnecessary state fields were removed from the CameraScreenViewModel
* new VM methods were added for handling a picked location (like the submit report VM)
* tests were updated to reflect the new UI composables and the new state logic

### 3. Location Selector
Now has a clear text button, and I also added a max line and overflow management in the text box to avoid overflowing and removing the icons.

## Related issues
Closes #370 

## UI Preview
<p align="center">
  <img src="https://github.com/user-attachments/assets/6c4eb24f-746b-43d4-b341-ca0311c61024" width="40%" />
  <img src="https://github.com/user-attachments/assets/f9606453-afde-4645-be59-24032173ecc0" width="40%" />
</p>

## Test
* Run all the screen + view model tests of the submit report and camera screens. They should all pass.
* Go to the post screen, there should be a location selector there. Verify it's working as intended by choosing a location.
* Verify that the (x) button clears the location and that the posted post does indeed not have any location attached to it.

## Additional Remarks
The submit report view model has some elvis operators marked as useless and to be removed, but once removed the compile of the tests fails so I will just leave it for now.


