### PR TITLE
feat: set image limits on the home page

### DIFF
--- a/app/src/main/java/com/android/wildex/ui/utils/images/ImageWithDoubleTap.kt
+++ b/app/src/main/java/com/android/wildex/ui/utils/images/ImageWithDoubleTap.kt
@@ -63,7 +63,7 @@ fun ImageWithDoubleTapLike(
         DoubleTapHeartOverlay(
             isVisible = isHeartOverlayVisible,
             onAnimationEnd = { isHeartOverlayVisible = false },
-            modifier = Modifier.fillMaxSize().align(Alignment.Center))
+            modifier = Modifier.align(Alignment.Center))
       }
 }
 


### PR DESCRIPTION
## Description
This PR just adds a little detail that was forgotten in #398. It adds a min and max height for a post slider, so it constrains the image and map size if the image is too tall or too short

## Related issues
Closes #428 

## Trade-offs and limitations
- I've accepted a sonar cloud issue regarding the use of `LocalConfiguration` instead of `LocalWindowInfo` since the latter will not yield the correct values and make the UI display the wrong dimensions
- I've accepted a sonar cloud issue regarding the cognitive complexity of `PostSlider` as other refactoring that would not break functionality or testing coverage would also have high complexity. 

## How to test
Simply re-run `HomeScreenTest`