### PR TITLE
fix: set error message when like offline

### DIFF
--- a/app/src/main/java/com/android/wildex/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/android/wildex/ui/home/HomeScreen.kt
@@ -242,7 +242,7 @@ fun HomeScreen(
                     listState = listState,
                     postStates = filteredPostStates,
                     onProfilePictureClick = onProfilePictureClick,
-                    onPostLike = homeScreenViewModel::toggleLike,
+                    onPostLike = { homeScreenViewModel.toggleLike(it, isOnline) },
                     onPostClick = onPostClick,
                 )
           }


### PR DESCRIPTION
## Description
This pull request introduces a fix. When liking a post while offline the app currently crashes. The problem comes from the fact that the `isOnline` variable is by default defined as true in the `toggleLike` function of the `HomeScreenViewModel`.
To fix it I simply pass the actual `isOnline` variable, that checks for connectivity.
Now, when online one can like or unlike a post, when offline, you try to like or unlike a post, you get a toast message explaining that posts cannot be liked offline.