### PR TITLE
feat: improve google maps sharing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,10 @@
     <!-- Include only if your app benefits from precise location access. -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
+    <queries>
+        <package android:name="com.google.android.apps.maps" />
+    </queries>
+
     <application
         android:allowBackup="true"
         android:networkSecurityConfig="@xml/network_security_config"

--- a/app/src/main/java/com/android/wildex/ui/post/PostDetailsActions.kt
+++ b/app/src/main/java/com/android/wildex/ui/post/PostDetailsActions.kt
@@ -58,9 +58,7 @@ fun PostDetailsActions(
 ) {
 
   val locationUri =
-      postLocation?.let {
-        "geo:${it.latitude},${it.longitude}?q=${it.latitude},${it.longitude}(${it.name})".toUri()
-      }
+      postLocation?.let { "google.navigation:q=${it.latitude},${it.longitude}&mode=d".toUri() }
   val context = LocalContext.current
   val clipboard = LocalClipboard.current
   val currentScope = rememberCoroutineScope()


### PR DESCRIPTION
## Description
This PR fixes the google maps sharing after the build update. It also changes the post details google maps sharing to directly start the navigation in google maps, like already done in the report details navigation options

## Related issues
Closes #437 

## How to test
Press the "Open in Google Maps" button in the post details action menu, or the report details navigation menu